### PR TITLE
fix(code): give code-index RPC its own 30m timeout

### DIFF
--- a/aide/cmd/aide/backend_code.go
+++ b/aide/cmd/aide/backend_code.go
@@ -175,7 +175,7 @@ func (b *Backend) IndexCode(paths []string, force bool) (*CodeIndexResult, error
 
 // IndexCodeWithProgress indexes code with an optional progress callback.
 func (b *Backend) IndexCodeWithProgress(paths []string, force bool, progress func(path string, symbols int)) (*CodeIndexResult, error) {
-	ctx, cancel := b.rpcCtx()
+	ctx, cancel := context.WithTimeout(context.Background(), CodeIndexRPCTimeout)
 	defer cancel()
 
 	if b.useGRPC {

--- a/aide/cmd/aide/constants.go
+++ b/aide/cmd/aide/constants.go
@@ -20,6 +20,13 @@ const (
 	// on large indexes.
 	DeadCodeAnalysisRPCTimeout = 5 * time.Minute
 
+	// CodeIndexRPCTimeout is the deadline for the code-index RPC. Indexing
+	// walks every source file under the requested paths, parses each via
+	// tree-sitter, and writes symbols to Bolt + Bleve. On large repos this
+	// runs well past the default 10s adapter.RPCTimeout, so it gets its
+	// own much larger budget.
+	CodeIndexRPCTimeout = 30 * time.Minute
+
 	// -------------------------------------------------------------------------
 	// Messages
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `aide code index` on larger codebases fails with `rpc error: code = DeadlineExceeded desc = context deadline exceeded` whenever the daemon is running, because `IndexCodeWithProgress` wraps the gRPC call in the default `adapter.RPCTimeout` (10s).
- Adds a dedicated `CodeIndexRPCTimeout = 30 * time.Minute` constant (mirrors the existing `DeadCodeAnalysisRPCTimeout` pattern) and uses it in `IndexCodeWithProgress`.
- Direct (non-daemon) mode was already unaffected — it ignores the context — so this only changes behaviour for the gRPC path.

## Test plan
- [x] `go build ./aide/cmd/aide/` is clean
- [ ] Reproduce the original timeout against a large repo with the daemon running, confirm indexing now completes
- [ ] Re-run on a small repo to confirm no regression in normal/short indexing runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)