### PR TITLE
feat(mcp): add memory_add tool to store memories over MCP

### DIFF
--- a/aide/cmd/aide/cmd_mcp_memory_test.go
+++ b/aide/cmd/aide/cmd_mcp_memory_test.go
@@ -24,8 +24,8 @@ func newMemoryTestServer(t *testing.T) (*MCPServer, func()) {
 }
 
 func TestHandleMemoryAdd_StoresAndReturnsID(t *testing.T) {
-	s, close := newMemoryTestServer(t)
-	defer close()
+	s, cleanup := newMemoryTestServer(t)
+	defer cleanup()
 
 	result, _, err := s.handleMemoryAdd(context.Background(), nil, MemoryAddInput{
 		Content:  "The tavern keeper always serves ale at room temperature",
@@ -57,8 +57,8 @@ func TestHandleMemoryAdd_StoresAndReturnsID(t *testing.T) {
 }
 
 func TestHandleMemoryAdd_DefaultsToLearningCategory(t *testing.T) {
-	s, close := newMemoryTestServer(t)
-	defer close()
+	s, cleanup := newMemoryTestServer(t)
+	defer cleanup()
 
 	result, _, err := s.handleMemoryAdd(context.Background(), nil, MemoryAddInput{
 		Content: "Default category fact",
@@ -72,8 +72,8 @@ func TestHandleMemoryAdd_DefaultsToLearningCategory(t *testing.T) {
 }
 
 func TestHandleMemoryAdd_EmptyContentIsError(t *testing.T) {
-	s, close := newMemoryTestServer(t)
-	defer close()
+	s, cleanup := newMemoryTestServer(t)
+	defer cleanup()
 
 	result, _, err := s.handleMemoryAdd(context.Background(), nil, MemoryAddInput{
 		Content: "   ",
@@ -85,8 +85,8 @@ func TestHandleMemoryAdd_EmptyContentIsError(t *testing.T) {
 }
 
 func TestHandleMemoryAdd_UnknownCategoryIsError(t *testing.T) {
-	s, close := newMemoryTestServer(t)
-	defer close()
+	s, cleanup := newMemoryTestServer(t)
+	defer cleanup()
 
 	result, _, err := s.handleMemoryAdd(context.Background(), nil, MemoryAddInput{
 		Content:  "A fact with a bogus category",
@@ -112,8 +112,8 @@ func TestHandleMemoryAdd_UnknownCategoryIsError(t *testing.T) {
 }
 
 func TestHandleMemoryAdd_ReservedCategoryIsError(t *testing.T) {
-	s, close := newMemoryTestServer(t)
-	defer close()
+	s, cleanup := newMemoryTestServer(t)
+	defer cleanup()
 
 	result, _, err := s.handleMemoryAdd(context.Background(), nil, MemoryAddInput{
 		Content:  "An instinct a caller shouldn't set",

--- a/aide/cmd/aide/cmd_mcp_memory_test.go
+++ b/aide/cmd/aide/cmd_mcp_memory_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jmylchreest/aide/aide/pkg/memory"
+	"github.com/jmylchreest/aide/aide/pkg/store"
+)
+
+// newMemoryTestServer spins up an MCPServer backed by a real BoltStore in a
+// temp dir so memory_add actually persists and is searchable.
+func newMemoryTestServer(t *testing.T) (*MCPServer, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.NewBoltStore(filepath.Join(dir, "memory.db"))
+	if err != nil {
+		t.Fatalf("failed to open bolt store: %v", err)
+	}
+	s := &MCPServer{store: st}
+	return s, func() { st.Close() }
+}
+
+func TestHandleMemoryAdd_StoresAndReturnsID(t *testing.T) {
+	s, close := newMemoryTestServer(t)
+	defer close()
+
+	result, _, err := s.handleMemoryAdd(context.Background(), nil, MemoryAddInput{
+		Content:  "The tavern keeper always serves ale at room temperature",
+		Category: string(memory.CategoryLearning),
+		Tags:     []string{"preferences", "fantasy"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := extractText(result)
+	if !strings.Contains(text, `"status":"stored"`) {
+		t.Errorf("expected status stored in %q", text)
+	}
+	if !strings.Contains(text, `"category":"learning"`) {
+		t.Errorf("expected category learning in %q", text)
+	}
+
+	// Verify it actually persisted and is searchable (read-after-write).
+	search, _, err := s.handleMemorySearch(context.Background(), nil, MemorySearchInput{
+		Query: "room temperature",
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("search error: %v", err)
+	}
+	if !strings.Contains(extractText(search), "room temperature") {
+		t.Errorf("search did not find added memory: %q", extractText(search))
+	}
+}
+
+func TestHandleMemoryAdd_DefaultsToLearningCategory(t *testing.T) {
+	s, close := newMemoryTestServer(t)
+	defer close()
+
+	result, _, err := s.handleMemoryAdd(context.Background(), nil, MemoryAddInput{
+		Content: "Default category fact",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(extractText(result), `"category":"learning"`) {
+		t.Errorf("expected default category learning in %q", extractText(result))
+	}
+}
+
+func TestHandleMemoryAdd_EmptyContentIsError(t *testing.T) {
+	s, close := newMemoryTestServer(t)
+	defer close()
+
+	result, _, err := s.handleMemoryAdd(context.Background(), nil, MemoryAddInput{
+		Content: "   ",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertIsError(t, result, "'content' is required")
+}

--- a/aide/cmd/aide/cmd_mcp_memory_test.go
+++ b/aide/cmd/aide/cmd_mcp_memory_test.go
@@ -83,3 +83,44 @@ func TestHandleMemoryAdd_EmptyContentIsError(t *testing.T) {
 	}
 	assertIsError(t, result, "'content' is required")
 }
+
+func TestHandleMemoryAdd_UnknownCategoryIsError(t *testing.T) {
+	s, close := newMemoryTestServer(t)
+	defer close()
+
+	result, _, err := s.handleMemoryAdd(context.Background(), nil, MemoryAddInput{
+		Content:  "A fact with a bogus category",
+		Category: "learnings",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertIsError(t, result, "unknown category")
+	assertIsError(t, result, `"learnings"`)
+
+	// A malformed category must not be persisted — nothing should be searchable.
+	search, _, err := s.handleMemorySearch(context.Background(), nil, MemorySearchInput{
+		Query: "bogus category",
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("search error: %v", err)
+	}
+	if strings.Contains(extractText(search), "bogus category") {
+		t.Errorf("memory with invalid category should not have been stored: %q", extractText(search))
+	}
+}
+
+func TestHandleMemoryAdd_ReservedCategoryIsError(t *testing.T) {
+	s, close := newMemoryTestServer(t)
+	defer close()
+
+	result, _, err := s.handleMemoryAdd(context.Background(), nil, MemoryAddInput{
+		Content:  "An instinct a caller shouldn't set",
+		Category: string(memory.CategoryInstinct),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertIsError(t, result, "set by aide, not by callers")
+}

--- a/aide/cmd/aide/cmd_mcp_tools.go
+++ b/aide/cmd/aide/cmd_mcp_tools.go
@@ -42,6 +42,12 @@ type MemoryListInput struct {
 	Limit    int    `json:"limit,omitempty" jsonschema:"Maximum results (default 50). Increase for comprehensive review."`
 }
 
+type MemoryAddInput struct {
+	Content  string   `json:"content" jsonschema:"The memory content to store. Should be a short, self-contained, factual statement (e.g. 'The user prefers pytest over unittest', 'Auth middleware lives at src/auth.ts'). Concise, specific, and durable — avoid session-specific noise."`
+	Category string   `json:"category,omitempty" jsonschema:"Category: learning (technical discoveries, default), decision (choices with rationale), issue (known problems/workarounds), discovery (swarm findings), blocker (things that stopped progress), abandoned (failed/rejected approaches). Defaults to learning."`
+	Tags     []string `json:"tags,omitempty" jsonschema:"Optional tags for grouping/lookup, e.g. ['preferences', 'auth']. Can be used as filters in searches and lists."`
+}
+
 type StateGetInput struct {
 	Key     string `json:"key" jsonschema:"State key: 'mode', 'modelTier', 'activeSkill', or custom keys"`
 	AgentID string `json:"agent_id,omitempty" jsonschema:"Agent ID for per-agent state (e.g., 'abc123'). Omit for global state."`
@@ -118,6 +124,22 @@ Prefer most recent when answering questions about preferences or decisions.
 **When to use:** Use this for broad review or when you need to see everything.
 Use memory_search instead when looking for specific topics or keywords.`,
 	}, s.handleMemoryList)
+
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name: "memory_add",
+		Description: `Store a new memory — a persistent, cross-session fact about the user or project.
+
+Memories are short, durable, self-contained factual statements that future sessions
+can recall via memory_search. Record user preferences, coding conventions, architectural
+facts, known issues, and blockers as you discover them.
+
+**When to use:** When you learn a stable fact worth remembering for later sessions
+(e.g. "user prefers X", "we decided on Y", "service Z is deployed at W").
+Prefer memory_add for distilled, lasting facts; formal architectural decisions with
+history should use the decision_* tools (decision_list / decision_get).
+
+Params: content (required), optional category (default learning), optional tags.`,
+	}, s.handleMemoryAdd)
 }
 
 func (s *MCPServer) handleMemorySearch(_ context.Context, _ *mcp.CallToolRequest, input MemorySearchInput) (*mcp.CallToolResult, any, error) {
@@ -187,6 +209,39 @@ func (s *MCPServer) handleMemoryList(_ context.Context, _ *mcp.CallToolRequest, 
 	}
 
 	return textResult(formatMemoriesMarkdown(memories)), nil, nil
+}
+
+func (s *MCPServer) handleMemoryAdd(_ context.Context, _ *mcp.CallToolRequest, input MemoryAddInput) (*mcp.CallToolResult, any, error) {
+	mcpLog.Printf("tool: memory_add category=%q tags=%v", input.Category, input.Tags)
+
+	if strings.TrimSpace(input.Content) == "" {
+		return errorResult("'content' is required"), nil, nil
+	}
+
+	mem := &memory.Memory{
+		Content:  input.Content,
+		Category: memory.Category(input.Category),
+		Tags:     input.Tags,
+	}
+	if mem.Category == "" {
+		mem.Category = memory.CategoryLearning
+	}
+
+	if err := s.store.AddMemory(mem); err != nil {
+		mcpLog.Printf("  error: %v", err)
+		return errorResult(fmt.Sprintf("add memory failed: %v", err)), nil, nil
+	}
+
+	mcpLog.Printf("  added: id=%s category=%s", mem.ID, mem.Category)
+
+	result, _ := json.Marshal(map[string]any{
+		"id":       mem.ID,
+		"category": mem.Category,
+		"content":  mem.Content,
+		"tags":     mem.Tags,
+		"status":   "stored",
+	})
+	return textResult(string(result)), nil, nil
 }
 
 // ============================================================================

--- a/aide/cmd/aide/cmd_mcp_tools.go
+++ b/aide/cmd/aide/cmd_mcp_tools.go
@@ -126,7 +126,7 @@ Use memory_search instead when looking for specific topics or keywords.`,
 	}, s.handleMemoryList)
 
 	mcp.AddTool(s.server, &mcp.Tool{
-		Name: "memory_add",
+		Name:        "memory_add",
 		InputSchema: categoryInputSchema[MemoryAddInput]("Category:", false),
 		Description: `Store a new memory — a persistent, cross-session fact about the user or project.
 

--- a/aide/cmd/aide/cmd_mcp_tools.go
+++ b/aide/cmd/aide/cmd_mcp_tools.go
@@ -44,8 +44,8 @@ type MemoryListInput struct {
 
 type MemoryAddInput struct {
 	Content  string   `json:"content" jsonschema:"The memory content to store. Should be a short, self-contained, factual statement (e.g. 'The user prefers pytest over unittest', 'Auth middleware lives at src/auth.ts'). Concise, specific, and durable — avoid session-specific noise."`
-	Category string   `json:"category,omitempty" jsonschema:"Category: learning (technical discoveries, default), decision (choices with rationale), issue (known problems/workarounds), discovery (swarm findings), blocker (things that stopped progress), abandoned (failed/rejected approaches). Defaults to learning."`
-	Tags     []string `json:"tags,omitempty" jsonschema:"Optional tags for grouping/lookup, e.g. ['preferences', 'auth']. Can be used as filters in searches and lists."`
+	Category string   `json:"category,omitempty" jsonschema:"Category for this memory. Defaults to learning."`
+	Tags     []string `json:"tags,omitempty" jsonschema:"Topic tags plus structured tags that control scoring and sharing — include at least one scope and one provenance tag. Scope (pick one): 'scope:global' for facts true everywhere (also gives learning memories top ranking), or 'project:<name>' for this project only. With neither, the memory won't share across repos. Provenance (pick one): 'source:user' if the user said it, 'source:discovered' if you found it while working. Optional: 'verified:true' when confirmed by running or reading code. Example: ['testing','vitest','project:myapp','source:discovered','verified:true']"`
 }
 
 type StateGetInput struct {
@@ -127,11 +127,15 @@ Use memory_search instead when looking for specific topics or keywords.`,
 
 	mcp.AddTool(s.server, &mcp.Tool{
 		Name: "memory_add",
+		InputSchema: categoryInputSchema[MemoryAddInput]("Category:", false),
 		Description: `Store a new memory — a persistent, cross-session fact about the user or project.
 
 Memories are short, durable, self-contained factual statements that future sessions
 can recall via memory_search. Record user preferences, coding conventions, architectural
 facts, known issues, and blockers as you discover them.
+
+**Use memory_search first** to check whether this fact is already stored before adding —
+avoid piling up duplicate memories.
 
 **When to use:** When you learn a stable fact worth remembering for later sessions
 (e.g. "user prefers X", "we decided on Y", "service Z is deployed at W").
@@ -218,13 +222,22 @@ func (s *MCPServer) handleMemoryAdd(_ context.Context, _ *mcp.CallToolRequest, i
 		return errorResult("'content' is required"), nil, nil
 	}
 
+	cat := memory.Category(input.Category)
+	if cat == "" {
+		cat = memory.CategoryLearning
+	}
+	if !memory.IsValidCategory(cat) {
+		return errorResult(fmt.Sprintf("unknown category %q; valid categories: %s",
+			cat, memory.CategoryHelp(false))), nil, nil
+	}
+	if memory.IsReservedCategory(cat) {
+		return errorResult(fmt.Sprintf("category %q is set by aide, not by callers", cat)), nil, nil
+	}
+
 	mem := &memory.Memory{
 		Content:  input.Content,
-		Category: memory.Category(input.Category),
+		Category: cat,
 		Tags:     input.Tags,
-	}
-	if mem.Category == "" {
-		mem.Category = memory.CategoryLearning
 	}
 
 	if err := s.store.AddMemory(mem); err != nil {


### PR DESCRIPTION
## Summary
Adds a `memory_add` MCP tool so agents can **store** memories through the MCP server,
not just read them. Currently `memory_search` and `memory_list` are read-only; writes
require shelling out to `aide memory add` from the CLI.

This lets any MCP-connected agent (Claude Code, Codex, OpenCode, Hermes) persist
cross-session facts directly through the server, matching the read tools.

## Changes
- `cmd_mcp_tools.go`: new `MemoryAddInput` `{content, category, tags}`, register the
  `memory_add` tool, and `handleMemoryAdd` handler.
- The handler:
  - requires non-empty `content` (clear error otherwise)
  - defaults `category` to `learning` when omitted
  - persists via `store.AddMemory` (sets ULID + timestamp)
  - returns `{id, category, content, tags, status}` as JSON
- `cmd_mcp_memory_test.go`: tests for store+search read-after-write, default category,
  and empty-content validation.

## Test
```
go test ./cmd/aide -run TestHandleMemoryAdd   # 3 tests pass
go test ./cmd/aide/                            # full suite passes
go vet ./cmd/aide/                             # clean
```

## Notes
- Follows the existing tool conventions (`errorResult`/`textResult`, typed input structs,
  `mcp.AddTool(s.server, ...)`, `mcpLog`).
- Reads were already exposed; this closes the write gap.