### PR TITLE
fix(memory): reconcile the declared and scored category sets

### DIFF
--- a/aide/cmd/aide/cmd_mcp_tools.go
+++ b/aide/cmd/aide/cmd_mcp_tools.go
@@ -20,11 +20,11 @@ import (
 type MemorySearchInput struct {
 	Query    string `json:"query" jsonschema:"Search query - uses bleve full-text search with: (1) standard word matching, (2) fuzzy matching for typos (fuzziness=1), (3) edge n-grams for prefix matching (2-15 chars), (4) n-grams for substring matching (3-8 chars). Multi-word queries use OR (any word matches). Use up to 10 distinct keywords like 'colour food preferences'. Fuzzy matching handles spelling variants automatically ('color' matches 'colour'), so synonyms are unnecessary."`
 	Limit    int    `json:"limit,omitempty" jsonschema:"Maximum results to return (default 10). Increase for broader recall."`
-	Category string `json:"category,omitempty" jsonschema:"Filter by category: learning, decision, issue, discovery, blocker"`
+	Category string `json:"category,omitempty" jsonschema:"Filter by category: learning, decision, issue, discovery, blocker, abandoned, gotcha, pattern, session, instinct"`
 }
 
 type MemoryListInput struct {
-	Category string `json:"category,omitempty" jsonschema:"Filter by category: learning, decision, issue, discovery, blocker. Leave empty for all."`
+	Category string `json:"category,omitempty" jsonschema:"Filter by category: learning, decision, issue, discovery, blocker, abandoned, gotcha, pattern, session, instinct. Leave empty for all."`
 	Limit    int    `json:"limit,omitempty" jsonschema:"Maximum results (default 50). Increase for comprehensive review."`
 }
 

--- a/aide/pkg/contextshare/format.go
+++ b/aide/pkg/contextshare/format.go
@@ -130,7 +130,7 @@ func IsShareableMemory(m *memory.Memory) bool {
 	// Always share gotchas, patterns, and decisions.
 	// Other categories (learning, issue, discovery, blocker) require explicit tags.
 	switch m.Category {
-	case "gotcha", "pattern":
+	case memory.CategoryGotcha, memory.CategoryPattern:
 		return true
 	case memory.CategoryDecision:
 		return true

--- a/aide/pkg/memory/scoring.go
+++ b/aide/pkg/memory/scoring.go
@@ -66,16 +66,19 @@ func DefaultScoringConfig() ScoringConfig {
 		WeightRecency:    0.25,
 		WeightAccess:     0.10,
 
+		// Every AllCategories entry needs a score here; the fallback is for
+		// unknown categories, not for ones we forgot.
 		CategoryScores: map[Category]float64{
 			CategoryAbandoned: 0.90,
+			CategoryInstinct:  0.85,
 			CategoryBlocker:   0.85,
 			CategoryIssue:     0.80,
+			CategoryGotcha:    0.75,
 			CategoryDiscovery: 0.70,
 			CategoryDecision:  0.65,
 			CategoryLearning:  0.60,
-			"session":         0.40,
-			"pattern":         0.60,
-			"gotcha":          0.75,
+			CategoryPattern:   0.60,
+			CategorySession:   0.40,
 		},
 		DefaultCategoryScore: 0.50,
 		GlobalLearningScore:  1.00,

--- a/aide/pkg/memory/scoring_test.go
+++ b/aide/pkg/memory/scoring_test.go
@@ -76,6 +76,26 @@ func TestScoreMemory_ManualOverrideClamped(t *testing.T) {
 	}
 }
 
+// gotcha, pattern and session were scored for months without ever being
+// declared, and instinct was declared without ever being scored. Pin both
+// directions so neither half can drift again.
+func TestEveryCategoryIsScored(t *testing.T) {
+	cfg := DefaultScoringConfig()
+
+	for _, c := range AllCategories {
+		if _, ok := cfg.CategoryScores[c]; !ok {
+			t.Errorf("category %q is declared but unscored — it would silently fall back to %.2f",
+				c, cfg.DefaultCategoryScore)
+		}
+	}
+
+	for c := range cfg.CategoryScores {
+		if !IsValidCategory(c) {
+			t.Errorf("category %q is scored but missing from AllCategories", c)
+		}
+	}
+}
+
 func TestScoreMemory_CategoryPriorityOrder(t *testing.T) {
 	cfg := DefaultScoringConfig()
 	now := time.Now()
@@ -94,7 +114,7 @@ func TestScoreMemory_CategoryPriorityOrder(t *testing.T) {
 		{CategoryIssue, tags},
 		{CategoryDiscovery, tags},
 		{CategoryLearning, tags}, // project learning (no scope:global)
-		{"session", tags},
+		{CategorySession, tags},
 	}
 
 	var prev = 2.0 // above max

--- a/aide/pkg/memory/types.go
+++ b/aide/pkg/memory/types.go
@@ -13,8 +13,37 @@ const (
 	CategoryDiscovery Category = "discovery" // Swarm findings (shared)
 	CategoryBlocker   Category = "blocker"   // Things that stopped progress
 	CategoryAbandoned Category = "abandoned" // Failed/rejected approaches (prevents loops)
+	CategoryGotcha    Category = "gotcha"    // Traps and footguns that cost time
+	CategoryPattern   Category = "pattern"   // Recurring convention worth following
+	CategorySession   Category = "session"   // Work log for one session; rarely durable
 	CategoryInstinct  Category = "instinct"  // Earned heuristic promoted from a reflect proposal
 )
+
+// AllCategories is the canonical set, ordered by the base importance the
+// scorer gives them. Validate against it rather than hardcoding a list.
+var AllCategories = []Category{
+	CategoryAbandoned,
+	CategoryInstinct,
+	CategoryBlocker,
+	CategoryIssue,
+	CategoryGotcha,
+	CategoryDiscovery,
+	CategoryDecision,
+	CategoryLearning,
+	CategoryPattern,
+	CategorySession,
+}
+
+// IsValidCategory reports whether c is known. Valid is not the same as
+// hand-writable: instinct is valid but only ever produced by reflect.
+func IsValidCategory(c Category) bool {
+	for _, known := range AllCategories {
+		if c == known {
+			return true
+		}
+	}
+	return false
+}
 
 // Memory represents a single memory entry.
 // Memories are short, transient user preferences or instructions.


### PR DESCRIPTION
`gotcha`, `pattern` and `session` were scored in `DefaultScoringConfig` as bare strings but never declared as `Category` constants, so anything enumerating the constants disagreed with the scorer about what counts as valid. `instinct` had the opposite problem — declared, never scored — so an accepted instinct fell through to the 0.50 unknown-category fallback and ranked *below* a plain `learning`, despite being the one category that passes an explicit promotion gate.

This declares the three missing constants, scores `instinct` at 0.85 alongside `blocker`, and adds `AllCategories` / `IsValidCategory` as the canonical set so callers stop hardcoding lists.

The full set, in scoring order:

| Category | Score |
|---|---|
| `abandoned` | 0.90 |
| `instinct` | 0.85 (was falling through to 0.50) |
| `blocker` | 0.85 |
| `issue` | 0.80 |
| `gotcha` | 0.75 |
| `discovery` | 0.70 |
| `decision` | 0.65 |
| `learning` | 0.60 |
| `pattern` | 0.60 |
| `session` | 0.40 |

`TestEveryCategoryIsScored` pins both directions — a declared category with no score, or a scored category not in `AllCategories`, now fails. Verified it catches both by temporarily removing `CategoryPattern` from the map and adding a bogus scored entry.

Also fixes the same drift in the MCP read tools: `memory_search` / `memory_list` advertised five of the ten categories in their `category` filter.

**One behavioural change worth flagging:** `instinct` memories move from an effective 0.50 to 0.85, so they get injected earlier. That's the intended reading of a promoted heuristic, but it is a ranking change and not a pure refactor.

Unblocks #32 — that PR needs category validation, and asking a contributor to validate against a set that disagreed with itself wasn't reasonable. With this merged there's `memory.IsValidCategory` to call.

`go build ./...`, `go test ./...` and `go vet ./...` all clean.