### PR TITLE
fix(hud): resolve the plugin root for local-path installs

### DIFF
--- a/scripts/aide-hud-wrapper.ts
+++ b/scripts/aide-hud-wrapper.ts
@@ -5,23 +5,56 @@
  * This is a thin wrapper that delegates to the real HUD script in the aide plugin.
  * This allows the plugin to update without requiring users to reinstall the wrapper.
  *
+ * Locating the plugin is the whole job here. The statusline is a
+ * user-settings command rather than a plugin hook, so the harness sets no
+ * CLAUDE_PLUGIN_ROOT when it runs us. session-start does know the root, and
+ * records it in the pointer file next to this script; the environment and
+ * the marketplace cache are the other two ways it can turn up.
+ *
  * The marker below makes the installed copy recognizably aide-managed:
  * session-start upgrades managed copies when the plugin ships a higher
  * version, and never touches files without a marker. Bump it whenever
  * this file changes.
  *
- * aide-wrapper-version: 2
+ * aide-wrapper-version: 3
  */
 
-import { existsSync, readdirSync, statSync } from "fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 import spawn from "cross-spawn";
 import { homedir } from "os";
 
+// Kept in step with hudPointerFile() in src/lib/hud.ts.
+const POINTER_FILE = join(homedir(), ".claude", "bin", "aide-hud.path");
+
+/** The HUD script a plugin root would hold, if it is really there. */
+function hudScriptIn(pluginRoot: string): string | null {
+  const script = join(pluginRoot, "scripts", "aide-hud.ts");
+  return existsSync(script) ? script : null;
+}
+
+/** Set when a hook or OpenCode invokes us rather than the statusline. */
+function fromEnv(): string | null {
+  const root = process.env.AIDE_PLUGIN_ROOT || process.env.CLAUDE_PLUGIN_ROOT;
+  return root ? hudScriptIn(root) : null;
+}
+
+/** The root session-start resolved, rewritten on every session start. */
+function fromPointer(): string | null {
+  try {
+    const root = readFileSync(POINTER_FILE, "utf-8").trim();
+    return root ? hudScriptIn(root) : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Find the newest aide plugin installation's HUD script
+ * Newest marketplace-cache install. Only reachable before the first
+ * session-start of a fresh install has written the pointer — and it misses
+ * local-path installs entirely, which is why it is the last resort.
  */
-function findHudScript(): string | null {
+function fromCache(): string | null {
   const cacheDir = join(homedir(), ".claude", "plugins", "cache");
 
   if (!existsSync(cacheDir)) return null;
@@ -68,7 +101,7 @@ function findHudScript(): string | null {
   return newest?.path ?? null;
 }
 
-const script = findHudScript();
+const script = fromEnv() ?? fromPointer() ?? fromCache();
 
 if (script) {
   const result = spawn.sync("bun", [script, ...process.argv.slice(2)], {
@@ -76,5 +109,7 @@ if (script) {
   });
   process.exit(result.status ?? 0);
 } else {
-  console.log("[aide] not installed");
+  // Never "not installed" — the rest of the plugin can be working fine and
+  // only this lookup have failed. Name what could not be found.
+  console.log("[aide] hud unavailable: no plugin root");
 }

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -34,7 +34,7 @@ import {
 } from "../lib/hook-utils.js";
 import { findAideBinary, ensureAideBinary } from "../lib/aide-downloader.js";
 import { findProjectRoot } from "../lib/project-root.js";
-import { shouldInstallWrapper } from "../lib/hud.js";
+import { shouldInstallWrapper, hudPointerFile } from "../lib/hud.js";
 import {
   resolveAnchorViaBinary,
   writeSessionAnchor,
@@ -168,6 +168,38 @@ function getPluginRoot(): string | null {
 }
 
 /**
+ * Point the installed HUD wrapper at this plugin root.
+ *
+ * The statusline runs as a user-settings command, so it inherits no
+ * CLAUDE_PLUGIN_ROOT and cannot locate the plugin itself — its old
+ * fallback, scanning the marketplace cache, never matched a local-path
+ * or dev install. We know the root here, so we write it down.
+ */
+function writeHudPointer(
+  claudeBinDir: string,
+  pluginRoot: string,
+  log: Logger,
+): void {
+  const pointer = hudPointerFile(claudeBinDir);
+  try {
+    const resolved = realpathSync(pluginRoot);
+    if (readFileSync(pointer, "utf-8").trim() === resolved) return;
+    writeFileSync(pointer, `${resolved}\n`);
+    log.info(`Pointed HUD wrapper at ${resolved}`);
+  } catch {
+    // Absent or unreadable -> write it; a failure here only costs the
+    // statusline its fast path, so never fail the session over it.
+    try {
+      if (!existsSync(claudeBinDir)) mkdirSync(claudeBinDir, { recursive: true });
+      writeFileSync(pointer, `${realpathSync(pluginRoot)}\n`);
+      log.info(`Pointed HUD wrapper at ${pluginRoot}`);
+    } catch (err) {
+      log.warn("Failed to write HUD pointer", err);
+    }
+  }
+}
+
+/**
  * Install the HUD wrapper script to ~/.claude/bin/
  *
  * This installs a thin wrapper that delegates to the real HUD script in the plugin.
@@ -186,6 +218,12 @@ function installHudWrapper(log: Logger): void {
     log.end("installHudWrapper", { skipped: true, reason: "no-plugin-root" });
     return;
   }
+
+  // Record the root before any early return below: the pointer has to track
+  // the current install every session, while the wrapper itself is only
+  // rewritten on a version bump — and an already-installed wrapper still
+  // needs pointing even from a package that ships no wrapper source.
+  writeHudPointer(claudeBinDir, pluginRoot, log);
 
   const wrapperSrc = join(pluginRoot, "scripts", "aide-hud-wrapper.ts");
   if (!existsSync(wrapperSrc)) {

--- a/src/lib/hud.ts
+++ b/src/lib/hud.ts
@@ -85,6 +85,25 @@ export function hudRenderCacheFile(sessionId: string): string | null {
   return join(base, "hud", `${sessionId}.json`);
 }
 
+/**
+ * The wrapper's pointer file: a single line holding the plugin root that
+ * session-start resolved. The statusline runs as a user-settings command,
+ * not a plugin hook, so it gets no CLAUDE_PLUGIN_ROOT in its environment
+ * and cannot find the plugin on its own — session-start knows the answer
+ * and records it here rather than making the wrapper guess.
+ *
+ * Deliberately separate from the wrapper file: the root changes on every
+ * plugin upgrade or reinstall, while the wrapper version changes rarely,
+ * and shouldInstallWrapper() must keep refusing to rewrite a wrapper whose
+ * version isn't strictly lower. Keep the wrapper's inlined reader
+ * (scripts/aide-hud-wrapper.ts) in step with this format.
+ */
+export const HUD_POINTER_FILENAME = "aide-hud.path";
+
+export function hudPointerFile(claudeBinDir: string): string {
+  return join(claudeBinDir, HUD_POINTER_FILENAME);
+}
+
 const WRAPPER_VERSION_RE = /aide-wrapper-version:\s*(\d+)/;
 // Wrappers deployed before the version marker existed all carry this
 // header; treat them as managed v1 so they upgrade exactly once.

--- a/src/test/statusline.test.ts
+++ b/src/test/statusline.test.ts
@@ -5,7 +5,12 @@ import {
   type StatuslineData,
   type StatuslinePayload,
 } from "../lib/statusline.js";
-import { shouldInstallWrapper, type AgentState } from "../lib/hud.js";
+import {
+  shouldInstallWrapper,
+  hudPointerFile,
+  HUD_POINTER_FILENAME,
+  type AgentState,
+} from "../lib/hud.js";
 
 // These goldens ARE the spec: each scenario pins the exact line the
 // statusline renders for a representative session state.
@@ -275,5 +280,36 @@ describe("shouldInstallWrapper", () => {
     expect(shouldInstallWrapper(shipped, shipped)).toBe(false);
     expect(shouldInstallWrapper(shipped, null)).toBe(true);
     expect(/aide-wrapper-version:\s*\d+/.test(shipped)).toBe(true);
+  });
+});
+
+describe("hud pointer file", () => {
+  it("sits beside the wrapper in ~/.claude/bin", () => {
+    expect(hudPointerFile("/home/u/.claude/bin")).toBe(
+      "/home/u/.claude/bin/aide-hud.path",
+    );
+  });
+
+  // The wrapper cannot import from the plugin — locating the plugin is what
+  // it exists to do — so it inlines the pointer path. These pin the two
+  // copies together; drift means a silently dead statusline.
+  it("the shipped wrapper reads the same filename this module writes", async () => {
+    const { readFileSync } = await import("fs");
+    const shipped = readFileSync("scripts/aide-hud-wrapper.ts", "utf-8");
+    expect(shipped).toContain(`"${HUD_POINTER_FILENAME}"`);
+  });
+
+  it("the shipped wrapper prefers env and pointer over the cache walk", async () => {
+    const { readFileSync } = await import("fs");
+    const shipped = readFileSync("scripts/aide-hud-wrapper.ts", "utf-8");
+    // Cache-only lookup was the v2 bug: it never matches a local-path install.
+    expect(shipped).toMatch(
+      /fromEnv\(\)\s*\?\?\s*fromPointer\(\)\s*\?\?\s*fromCache\(\)/,
+    );
+    expect(shipped).toContain("AIDE_PLUGIN_ROOT");
+    // Failing this lookup says nothing about whether aide is installed —
+    // hooks, MCP and skills resolve independently and can all be working.
+    expect(shipped).not.toContain('console.log("[aide] not installed")');
+    expect(shipped).toContain('console.log("[aide] hud unavailable');
   });
 });


### PR DESCRIPTION
The statusline printed `[aide] not installed` while hooks, MCP and skills were all resolving fine off the same install.

The statusline is a user-settings command rather than a plugin hook, so it inherits no `CLAUDE_PLUGIN_ROOT` and the wrapper has to locate the plugin itself. It only ever looked under `~/.claude/plugins/cache/*/aide/*/scripts/aide-hud.ts`, which never matches an install whose `installPath` is a local checkout — so any dev or local-path install has had a dead statusline, with a message actively pointing at the wrong cause.

`session-start` already resolves the root via `getPluginRoot()`, so it now records it in a pointer file next to the wrapper instead of leaving the wrapper to guess. Resolution order:

1. `AIDE_PLUGIN_ROOT` / `CLAUDE_PLUGIN_ROOT` — set when a hook or OpenCode invokes it
2. `~/.claude/bin/aide-hud.path` — written every session by `session-start`
3. the original cache walk, kept as a last resort

The pointer is deliberately a sidecar rather than a path baked into the wrapper body: the root changes on every upgrade or reinstall while the wrapper version changes rarely, and `shouldInstallWrapper` must keep refusing to rewrite a wrapper whose version isn't strictly lower. A baked-in path would need a rewrite that rule would correctly refuse, leaving it pointing at a deleted directory. Writing it happens before both early returns in `installHudWrapper`, so it tracks the current install every session — including from the OpenCode package, which ships no `scripts/` of its own.

It also drops a ~300ms-cadence recursive `readdirSync` of the plugins cache down to one `existsSync` plus a small read.

Wrapper bumped to `aide-wrapper-version: 3` so existing installs upgrade themselves.

Tests pin the pointer path and hold the wrapper's inlined copy against `HUD_POINTER_FILENAME` and the tier order — the wrapper can't import from the plugin (locating the plugin is its whole job), so drift between the two copies is exactly how this breaks again. Also changed the failure message from `[aide] not installed` to `[aide] hud unavailable: no plugin root`, since failing this lookup says nothing about whether aide is installed.

Verified all three tiers against a real install:

```
no pointer, no env  → [aide] hud unavailable: no plugin root
env set             → [aide 0.1.14-dev.1+7f43dfe] …/jmylchreest/aide | ⚒21
pointer             → [aide 0.1.14-dev.1+7f43dfe] …/jmylchreest/aide | ⚒21
```

Upgrade logic: v3 over v2 → true, over itself → false, over a user-owned file → false. `tsc --noEmit` clean, 553 vitest tests pass, and the statusline file passes under `bun test` too.