### PR TITLE
feat(aideignore): honour .gitignore, and parse all ignore patterns with go-git

### DIFF
--- a/aide/cmd/aide/cmd_config.go
+++ b/aide/cmd/aide/cmd_config.go
@@ -229,11 +229,12 @@ func printResolvedConfig(cfg *config.Config) {
 	fmt.Printf("  index_workers   %d\n", cfg.IndexWorkers)
 
 	fmt.Println("\ncode")
-	fmt.Printf("  watch           %v\n", cfg.Code.Watch)
-	fmt.Printf("  watch_paths     %s\n", emptyDash(cfg.Code.WatchPaths))
-	fmt.Printf("  watch_delay     %s\n", emptyDash(cfg.Code.WatchDelay))
-	fmt.Printf("  store_enabled   %v\n", cfg.Code.StoreEnabled)
-	fmt.Printf("  store_sync      %v\n", cfg.Code.StoreSync)
+	fmt.Printf("  %-17s %v\n", "watch", cfg.Code.Watch)
+	fmt.Printf("  %-17s %s\n", "watch_paths", emptyDash(cfg.Code.WatchPaths))
+	fmt.Printf("  %-17s %s\n", "watch_delay", emptyDash(cfg.Code.WatchDelay))
+	fmt.Printf("  %-17s %v\n", "store_enabled", cfg.Code.StoreEnabled)
+	fmt.Printf("  %-17s %v\n", "store_sync", cfg.Code.StoreSync)
+	fmt.Printf("  %-17s %v\n", "respect_gitignore", cfg.Code.RespectGitignoreEnabled())
 
 	fmt.Println("\npprof")
 	fmt.Printf("  enable          %v\n", cfg.Pprof.Enable)
@@ -533,11 +534,14 @@ func resolveValue(k *koanf.Koanf, cfg *config.Config, fi config.FieldInfo) any {
 	}
 }
 
-// ptrBoolDefault resolves the four share *bool keys through their accessor
-// defaults when neither file nor env set them. Any other *bool key (none today)
-// defaults to false.
+// ptrBoolDefault resolves a *bool key through its accessor default when
+// neither file nor env set it. Every *bool leaf in the schema needs an entry
+// here — a missing one silently reports false for a key whose real default is
+// true, so TestPtrBoolDefaultsCoverSchema fails the build when the two drift.
 func ptrBoolDefault(cfg *config.Config, key string) bool {
 	switch key {
+	case "code.respect_gitignore":
+		return cfg.Code.RespectGitignoreEnabled()
 	case "share.decisions.export":
 		return cfg.Share.DecisionExportEnabled()
 	case "share.decisions.import":
@@ -549,6 +553,16 @@ func ptrBoolDefault(cfg *config.Config, key string) bool {
 	default:
 		return false
 	}
+}
+
+// ptrBoolKeys lists every *bool key ptrBoolDefault knows how to resolve. Kept
+// beside the switch so the guard test can compare it against the schema.
+var ptrBoolKeys = []string{
+	"code.respect_gitignore",
+	"share.decisions.export",
+	"share.decisions.import",
+	"share.memories.export",
+	"share.memories.import",
 }
 
 // formatValue renders a resolved value for human output: bools and ints

--- a/aide/cmd/aide/cmd_config_test.go
+++ b/aide/cmd/aide/cmd_config_test.go
@@ -202,6 +202,46 @@ func TestConfigGetPtrBoolDefault(t *testing.T) {
 	}
 }
 
+func TestConfigGetRespectGitignoreDefault(t *testing.T) {
+	dbPath, _ := newConfigProject(t)
+	// Nothing set: the gitignore layer is on, so `config get` must say true
+	// rather than the nil *bool's zero value.
+	out := captureStdout(t, func() {
+		if err := cmdConfigGet(dbPath, []string{"code.respect_gitignore"}); err != nil {
+			t.Fatalf("get: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "true" {
+		t.Errorf("get code.respect_gitignore = %q, want true", strings.TrimSpace(out))
+	}
+}
+
+// TestPtrBoolDefaultsCoverSchema guards the hand-maintained switch in
+// ptrBoolDefault against the reflection-driven schema. A *bool leaf missing
+// from the switch reports false for an unset key, which is wrong for every
+// *bool whose default is on — the exact bug adding code.respect_gitignore hit.
+func TestPtrBoolDefaultsCoverSchema(t *testing.T) {
+	known := map[string]bool{}
+	for _, k := range ptrBoolKeys {
+		known[k] = true
+	}
+
+	for _, fi := range config.Schema() {
+		if fi.Kind != config.KindPtrBool {
+			continue
+		}
+		if !known[fi.Key] {
+			t.Errorf("*bool key %q has no case in ptrBoolDefault — unset reads as false", fi.Key)
+		}
+	}
+
+	for _, k := range ptrBoolKeys {
+		if _, ok := config.Lookup(k); !ok {
+			t.Errorf("ptrBoolKeys lists %q, which is not in the config schema", k)
+		}
+	}
+}
+
 func TestConfigShowAllHumanAndJSON(t *testing.T) {
 	dbPath, root := newConfigProject(t)
 	if err := cmdConfigSet(dbPath, []string{"share.decisions.export", "false"}); err != nil {

--- a/aide/go.mod
+++ b/aide/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/ebitengine/purego v0.10.2
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/jsonschema-go v0.4.3
 	github.com/knadh/koanf/parsers/json v1.0.1
@@ -88,7 +89,6 @@ require (
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/flier/gohs v1.2.3 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect

--- a/aide/pkg/aideignore/aideignore.go
+++ b/aide/pkg/aideignore/aideignore.go
@@ -12,9 +12,6 @@
 // git's rather than an approximation of them: the last matching pattern wins,
 // "!" re-includes, a trailing "/" restricts a pattern to directories, "**"
 // spans path segments, and a leading "/" anchors to the domain root.
-//
-// A single Matcher exposes ShouldIgnore, used by all findings analysers, the
-// file watcher, and the Runner.
 package aideignore
 
 import (
@@ -216,7 +213,6 @@ func NewEmpty() *Matcher {
 	return newMatcher(nil)
 }
 
-// newMatcher compiles a pattern slice into a Matcher.
 func newMatcher(ps []gitignore.Pattern) *Matcher {
 	return &Matcher{matcher: gitignore.NewMatcher(ps)}
 }
@@ -231,8 +227,6 @@ func newFromPatternStrings(patterns ...string) *Matcher {
 	return newMatcher(ps)
 }
 
-// builtinOnce guards the one-time parse of BuiltinDefaults. Parsed patterns are
-// immutable and shared by every Matcher.
 var (
 	builtinOnce sync.Once
 	builtinPS   []gitignore.Pattern
@@ -245,7 +239,7 @@ func builtinPatterns() []gitignore.Pattern {
 			builtinPS = append(builtinPS, gitignore.ParsePattern(p, nil))
 		}
 	})
-	// Copy so a caller appending later layers cannot write into the shared
+	// Copied so a caller appending later layers cannot write into the shared
 	// backing array.
 	out := make([]gitignore.Pattern, len(builtinPS))
 	copy(out, builtinPS)
@@ -258,13 +252,7 @@ func builtinPatterns() []gitignore.Pattern {
 // The path should use forward slashes and be relative to the project root.
 // Both "foo/bar" and "foo/bar/" are accepted for directories (the trailing
 // slash is stripped internally; use the isDir flag instead).
-//
-// Directory-only patterns also ignore paths beneath them, so a file path like
-// "vendor/github.com/foo/bar.go" is ignored by "vendor/" even when the walk
-// never had a chance to prune the parent directory — the case OnChanges hits
-// when it receives individual file paths.
 func (m *Matcher) ShouldIgnore(path string, isDir bool) bool {
-	// Normalise to forward slashes and strip any trailing slash.
 	path = filepath.ToSlash(path)
 	path = strings.TrimSuffix(path, "/")
 
@@ -318,10 +306,8 @@ func (m *Matcher) WalkFunc(projectRoot string) func(path string, info os.FileInf
 }
 
 // readPatternFile parses one ignore file into patterns rooted at domain. It
-// mirrors go-git's unexported readIgnoreFile, which cannot be called directly:
-// blank lines and "#" comments are skipped, every other line is a pattern.
-// Unlike git, leading whitespace is trimmed — .aideignore has always been
-// lenient about indented patterns and staying compatible costs nothing.
+// mirrors go-git's unexported readIgnoreFile. Unlike git, leading whitespace is
+// trimmed — .aideignore has always been lenient about indented patterns.
 func readPatternFile(path string, domain []string) ([]gitignore.Pattern, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/aide/pkg/aideignore/aideignore.go
+++ b/aide/pkg/aideignore/aideignore.go
@@ -1,19 +1,20 @@
 // Package aideignore provides gitignore-compatible file matching for aide.
 //
-// It loads patterns from a project's .aideignore file (if present), merges them
-// with built-in defaults for generated code, build artifacts, and common
-// non-source directories, and exposes a single ShouldIgnore method used by all
-// findings analysers, the file watcher, and the Runner.
+// Patterns come from three layered sources, in increasing priority:
 //
-// Pattern syntax mirrors .gitignore:
+//  1. BuiltinDefaults — generated code, build output, common vendored dirs.
+//  2. The repository's own ignore rules — .git/info/exclude plus every
+//     .gitignore in the tree — when enabled. See Options.Gitignore.
+//  3. <projectRoot>/.aideignore — project overrides, which can re-include
+//     anything the layers above ignored via a leading "!".
 //
-//	# comment
-//	*.pb.go          — match files by extension
-//	vendor/          — match directories by name (trailing slash)
-//	**/test/         — match at any depth
-//	!important.go    — negate a previous pattern
-//	build/           — directory name anywhere in tree
-//	/rootonly        — anchored to project root (leading slash)
+// All three are parsed by go-git's gitignore package, so the semantics are
+// git's rather than an approximation of them: the last matching pattern wins,
+// "!" re-includes, a trailing "/" restricts a pattern to directories, "**"
+// spans path segments, and a leading "/" anchors to the domain root.
+//
+// A single Matcher exposes ShouldIgnore, used by all findings analysers, the
+// file watcher, and the Runner.
 package aideignore
 
 import (
@@ -21,18 +22,30 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+
+	"github.com/jmylchreest/aide/aide/pkg/config"
 )
+
+// IgnoreFileName is the project-relative ignore file aide reads for
+// project-specific overrides.
+const IgnoreFileName = ".aideignore"
 
 // Matcher tests whether a path should be ignored.
 type Matcher struct {
-	rules []rule
+	matcher gitignore.Matcher
 }
 
-type rule struct {
-	pattern  string
-	negation bool
-	dirOnly  bool
-	anchored bool // pattern contains '/' (other than trailing) — anchored to root
+// Options tunes which pattern sources a Matcher loads. The zero value loads
+// built-in defaults and .aideignore only.
+type Options struct {
+	// Gitignore layers the repository's own ignore rules between the built-in
+	// defaults and .aideignore. It is a no-op when projectRoot has no .git.
+	Gitignore bool
 }
 
 // BuiltinDefaults are patterns applied even when no .aideignore file exists.
@@ -158,39 +171,85 @@ var BuiltinDefaults = []string{
 	"*.lock",
 }
 
-// New creates a Matcher from built-in defaults plus an optional .aideignore
-// file located at <projectRoot>/.aideignore. If the file does not exist the
-// Matcher still works using only built-in defaults.
+// New creates a Matcher for a project root, reading the gitignore layer
+// according to code.respect_gitignore (default on). Callers that must pin the
+// behaviour regardless of user config should use NewWithOptions.
 func New(projectRoot string) (*Matcher, error) {
-	m := &Matcher{}
+	return NewWithOptions(projectRoot, Options{
+		Gitignore: config.Get().Code.RespectGitignoreEnabled(),
+	})
+}
 
-	// Load built-in defaults first (lowest priority).
-	for _, p := range BuiltinDefaults {
-		m.rules = append(m.rules, parsePattern(p))
+// NewWithOptions creates a Matcher from built-in defaults, optionally the
+// repository's gitignore rules, and an optional <projectRoot>/.aideignore
+// file. A missing .aideignore is not an error — the Matcher still works using
+// the layers below it.
+func NewWithOptions(projectRoot string, opts Options) (*Matcher, error) {
+	// Ordered lowest-priority first: go-git's matcher walks the slice in
+	// reverse and stops at the first pattern that matches, so appending later
+	// means overriding earlier. .aideignore going last is what lets a "!" line
+	// there re-include something a builtin or a .gitignore excluded.
+	ps := builtinPatterns()
+
+	if opts.Gitignore {
+		ps = append(ps, gitignorePatterns(projectRoot)...)
 	}
 
-	// Load user overrides from .aideignore (higher priority — can negate builtins).
-	ignoreFile := filepath.Join(projectRoot, ".aideignore")
-	if err := m.loadFile(ignoreFile); err != nil && !os.IsNotExist(err) {
+	userPS, err := readPatternFile(filepath.Join(projectRoot, IgnoreFileName), nil)
+	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
+	ps = append(ps, userPS...)
 
-	return m, nil
+	return newMatcher(ps), nil
 }
 
-// NewFromDefaults creates a Matcher using only built-in defaults (no file).
+// NewFromDefaults creates a Matcher using only built-in defaults (no file,
+// no gitignore layer).
 func NewFromDefaults() *Matcher {
-	m := &Matcher{}
-	for _, p := range BuiltinDefaults {
-		m.rules = append(m.rules, parsePattern(p))
-	}
-	return m
+	return newMatcher(builtinPatterns())
 }
 
-// NewEmpty creates a Matcher with no rules at all — nothing is ignored.
+// NewEmpty creates a Matcher with no patterns at all — nothing is ignored.
 // Use this in tests that need to scan testdata or other normally-excluded paths.
 func NewEmpty() *Matcher {
-	return &Matcher{}
+	return newMatcher(nil)
+}
+
+// newMatcher compiles a pattern slice into a Matcher.
+func newMatcher(ps []gitignore.Pattern) *Matcher {
+	return &Matcher{matcher: gitignore.NewMatcher(ps)}
+}
+
+// newFromPatternStrings builds a Matcher from raw pattern strings rooted at the
+// project root. Used by tests to exercise individual patterns in isolation.
+func newFromPatternStrings(patterns ...string) *Matcher {
+	ps := make([]gitignore.Pattern, 0, len(patterns))
+	for _, p := range patterns {
+		ps = append(ps, gitignore.ParsePattern(p, nil))
+	}
+	return newMatcher(ps)
+}
+
+// builtinOnce guards the one-time parse of BuiltinDefaults. Parsed patterns are
+// immutable and shared by every Matcher.
+var (
+	builtinOnce sync.Once
+	builtinPS   []gitignore.Pattern
+)
+
+func builtinPatterns() []gitignore.Pattern {
+	builtinOnce.Do(func() {
+		builtinPS = make([]gitignore.Pattern, 0, len(BuiltinDefaults))
+		for _, p := range BuiltinDefaults {
+			builtinPS = append(builtinPS, gitignore.ParsePattern(p, nil))
+		}
+	})
+	// Copy so a caller appending later layers cannot write into the shared
+	// backing array.
+	out := make([]gitignore.Pattern, len(builtinPS))
+	copy(out, builtinPS)
+	return out
 }
 
 // ShouldIgnore reports whether the given path (relative to the project root)
@@ -199,6 +258,11 @@ func NewEmpty() *Matcher {
 // The path should use forward slashes and be relative to the project root.
 // Both "foo/bar" and "foo/bar/" are accepted for directories (the trailing
 // slash is stripped internally; use the isDir flag instead).
+//
+// Directory-only patterns also ignore paths beneath them, so a file path like
+// "vendor/github.com/foo/bar.go" is ignored by "vendor/" even when the walk
+// never had a chance to prune the parent directory — the case OnChanges hits
+// when it receives individual file paths.
 func (m *Matcher) ShouldIgnore(path string, isDir bool) bool {
 	// Normalise to forward slashes and strip any trailing slash.
 	path = filepath.ToSlash(path)
@@ -208,47 +272,7 @@ func (m *Matcher) ShouldIgnore(path string, isDir bool) bool {
 		return false
 	}
 
-	// Evaluate rules in order — last matching rule wins.
-	ignored := false
-	matched := false // whether any rule matched this exact path
-	for _, r := range m.rules {
-		if r.dirOnly && !isDir {
-			continue
-		}
-		if r.match(path) {
-			ignored = !r.negation
-			matched = true
-		}
-	}
-
-	if ignored {
-		return true
-	}
-
-	// If a rule explicitly un-ignored this file (negation), respect that
-	// and skip the parent directory check. This allows patterns like
-	// "!testdata/important.txt" to override "testdata/".
-	if matched {
-		return false
-	}
-
-	// If the path is a file (not a directory), also check whether any parent
-	// directory is ignored. This handles the case where OnChanges receives
-	// individual file paths like "vendor/github.com/foo/bar.go" — the
-	// dir-only pattern "vendor/" should cause this file to be ignored even
-	// though filepath.Walk would normally skip the directory before reaching
-	// the file.
-	if !isDir {
-		parts := strings.Split(path, "/")
-		for i := 1; i <= len(parts)-1; i++ {
-			parent := strings.Join(parts[:i], "/")
-			if m.ShouldIgnore(parent, true) {
-				return true
-			}
-		}
-	}
-
-	return false
+	return m.matcher.Match(strings.Split(path, "/"), isDir)
 }
 
 // ShouldIgnoreDir is a convenience for ShouldIgnore(path, true).
@@ -293,173 +317,89 @@ func (m *Matcher) WalkFunc(projectRoot string) func(path string, info os.FileInf
 	}
 }
 
-// loadFile reads patterns from a .aideignore file.
-func (m *Matcher) loadFile(path string) error {
+// readPatternFile parses one ignore file into patterns rooted at domain. It
+// mirrors go-git's unexported readIgnoreFile, which cannot be called directly:
+// blank lines and "#" comments are skipped, every other line is a pattern.
+// Unlike git, leading whitespace is trimmed — .aideignore has always been
+// lenient about indented patterns and staying compatible costs nothing.
+func readPatternFile(path string, domain []string) ([]gitignore.Pattern, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer f.Close()
 
+	var ps []gitignore.Pattern
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-
-		// Skip empty lines and comments.
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-
-		m.rules = append(m.rules, parsePattern(line))
+		ps = append(ps, gitignore.ParsePattern(line, domain))
 	}
-	return scanner.Err()
+	return ps, scanner.Err()
 }
 
-// parsePattern converts a gitignore-style pattern string into a rule.
-func parsePattern(pattern string) rule {
-	r := rule{}
+// gitignoreTTL bounds how long a cached gitignore scan is reused. Long enough
+// that a findings run — which builds a Matcher per analyser — walks the tree
+// once, short enough that editing .gitignore takes effect in a running daemon
+// without a restart.
+const gitignoreTTL = 30 * time.Second
 
-	// Handle negation.
-	if strings.HasPrefix(pattern, "!") {
-		r.negation = true
-		pattern = pattern[1:]
-	}
-
-	// Handle trailing slash (directory-only pattern).
-	if strings.HasSuffix(pattern, "/") {
-		r.dirOnly = true
-		pattern = strings.TrimSuffix(pattern, "/")
-	}
-
-	// Handle leading slash (anchored to root).
-	if strings.HasPrefix(pattern, "/") {
-		r.anchored = true
-		pattern = strings.TrimPrefix(pattern, "/")
-	}
-
-	// A pattern is also anchored if it contains a slash anywhere (like "foo/bar").
-	// Patterns without slashes match against the basename at any depth.
-	if !r.anchored && strings.Contains(pattern, "/") {
-		// Contains a slash but not leading — still anchored to root per gitignore rules.
-		r.anchored = true
-	}
-
-	r.pattern = pattern
-	return r
+type gitignoreEntry struct {
+	patterns []gitignore.Pattern
+	loadedAt time.Time
 }
 
-// match tests whether a rule matches the given path.
-// path is relative to the project root, forward-slash separated, no trailing slash.
-func (r *rule) match(path string) bool {
-	pattern := r.pattern
+var (
+	gitignoreMu    sync.Mutex
+	gitignoreCache = map[string]gitignoreEntry{}
+)
 
-	// Handle ** prefix: matches zero or more directories.
-	if strings.HasPrefix(pattern, "**/") {
-		// "**/<rest>" matches <rest> at any depth.
-		rest := pattern[3:]
-		return matchGlob(rest, path) || matchGlob(rest, basename(path)) || matchPathSuffix(rest, path)
+// gitignorePatterns reads .git/info/exclude and every .gitignore in the tree
+// below projectRoot, in git's own precedence order.
+//
+// Deliberately excluded: the global (core.excludesfile) and system ignore
+// files. Those live outside the repository and differ per machine, so folding
+// them in would let the same tree produce different findings on different
+// checkouts with nothing in the repo to explain why.
+//
+// Errors are swallowed rather than surfaced: an unreadable ignore file should
+// degrade to "ignore less", never fail a scan. ReadPatterns also returns the
+// patterns it collected before an error, so partial results are worth keeping.
+func gitignorePatterns(projectRoot string) []gitignore.Pattern {
+	// A project root that is not a worktree root has nothing to read, and
+	// ReadPatterns would walk the whole tree to discover that. This also means
+	// a projectRoot nested inside a repo does not inherit its parents' rules.
+	if _, err := os.Stat(filepath.Join(projectRoot, ".git")); err != nil {
+		return nil
 	}
 
-	// Handle ** suffix: "<prefix>/**" matches everything under prefix.
-	if strings.HasSuffix(pattern, "/**") {
-		prefix := pattern[:len(pattern)-3]
-		return path == prefix || strings.HasPrefix(path, prefix+"/")
+	key, err := filepath.Abs(projectRoot)
+	if err != nil {
+		key = projectRoot
 	}
 
-	// Handle interior **: "a/**/b" matches a/b, a/x/b, a/x/y/b, etc.
-	if strings.Contains(pattern, "/**/") {
-		parts := strings.SplitN(pattern, "/**/", 2)
-		// Left part must match a prefix, right part must match the suffix.
-		if matchGlob(parts[0], path) {
-			return true
-		}
-		// Check: left prefix + any middle + right suffix.
-		return matchDoublestar(parts[0], parts[1], path)
+	gitignoreMu.Lock()
+	defer gitignoreMu.Unlock()
+
+	if e, ok := gitignoreCache[key]; ok && time.Since(e.loadedAt) < gitignoreTTL {
+		return e.patterns
 	}
 
-	if r.anchored {
-		// Anchored: pattern must match from the root.
-		return matchGlob(pattern, path)
-	}
-
-	// Unanchored: pattern matches against basename or any path component.
-	if matchGlob(pattern, basename(path)) {
-		return true
-	}
-	// Also check the full path for patterns like "*.pb.go" that should match
-	// "foo/bar.pb.go".
-	return matchGlob(pattern, path)
+	// ReadPatterns prunes as it recurses — a directory already excluded by the
+	// patterns collected so far is not descended into — so this does not walk
+	// node_modules or any other gitignored tree.
+	ps, _ := gitignore.ReadPatterns(osfs.New(key), nil)
+	gitignoreCache[key] = gitignoreEntry{patterns: ps, loadedAt: time.Now()}
+	return ps
 }
 
-// matchGlob performs filepath.Match but segment-by-segment for patterns
-// containing "/", so that "foo/*.go" properly matches "foo/bar.go".
-func matchGlob(pattern, name string) bool {
-	// If pattern has no slash, simple match.
-	if !strings.Contains(pattern, "/") {
-		ok, _ := filepath.Match(pattern, name)
-		return ok
-	}
-
-	// Match segment-by-segment.
-	patParts := strings.Split(pattern, "/")
-	nameParts := strings.Split(name, "/")
-
-	if len(patParts) != len(nameParts) {
-		return false
-	}
-
-	for i, pp := range patParts {
-		ok, _ := filepath.Match(pp, nameParts[i])
-		if !ok {
-			return false
-		}
-	}
-	return true
-}
-
-// matchPathSuffix checks if pattern matches any suffix of path split by "/".
-// For example, pattern "test/*.go" matches path "a/b/test/foo.go".
-func matchPathSuffix(pattern string, path string) bool {
-	parts := strings.Split(path, "/")
-	patParts := strings.Split(pattern, "/")
-
-	if len(patParts) > len(parts) {
-		return false
-	}
-
-	// Slide window over path parts.
-	for i := 0; i <= len(parts)-len(patParts); i++ {
-		candidate := strings.Join(parts[i:i+len(patParts)], "/")
-		if matchGlob(pattern, candidate) {
-			return true
-		}
-	}
-	return false
-}
-
-// matchDoublestar matches "left/**/right" against path.
-func matchDoublestar(left, right, path string) bool {
-	parts := strings.Split(path, "/")
-	// Find positions where left matches parts[:i] and right matches parts[j:]
-	for i := 0; i <= len(parts); i++ {
-		leftCandidate := strings.Join(parts[:i], "/")
-		if !matchGlob(left, leftCandidate) {
-			continue
-		}
-		for j := i; j <= len(parts); j++ {
-			rightCandidate := strings.Join(parts[j:], "/")
-			if matchGlob(right, rightCandidate) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// basename returns the last path component.
-func basename(path string) string {
-	if i := strings.LastIndex(path, "/"); i >= 0 {
-		return path[i+1:]
-	}
-	return path
+// InvalidateGitignoreCache drops every cached gitignore scan. Call it after
+// knowingly rewriting a .gitignore rather than waiting out gitignoreTTL.
+func InvalidateGitignoreCache() {
+	gitignoreMu.Lock()
+	gitignoreCache = map[string]gitignoreEntry{}
+	gitignoreMu.Unlock()
 }

--- a/aide/pkg/aideignore/aideignore_test.go
+++ b/aide/pkg/aideignore/aideignore_test.go
@@ -479,3 +479,151 @@ func TestUnloadedConfigDefaultsGitignoreOn(t *testing.T) {
 		t.Error("expected RespectGitignore to default on with no config loaded")
 	}
 }
+
+func TestGitInfoExcludeRead(t *testing.T) {
+	// .git/info/exclude is the untracked-but-ignored list. It is documented as
+	// part of the gitignore layer but nothing exercised it.
+	dir := writeGitRepo(t, map[string]string{
+		".git/info/exclude": "scratch/\n",
+	})
+
+	m, err := NewWithOptions(dir, Options{Gitignore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.ShouldIgnoreDir("scratch") {
+		t.Error("expected .git/info/exclude patterns to be honoured")
+	}
+}
+
+func TestLinkedWorktreeGitFile(t *testing.T) {
+	// In a linked worktree .git is a file pointing at the real gitdir, not a
+	// directory. The root .gitignore must still be read, and the failed
+	// .git/info/exclude open must not surface as an error.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: /elsewhere/.git/worktrees/wt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("artifacts/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	InvalidateGitignoreCache()
+
+	m, err := NewWithOptions(dir, Options{Gitignore: true})
+	if err != nil {
+		t.Fatalf("linked worktree should not error: %v", err)
+	}
+	if !m.ShouldIgnoreDir("artifacts") {
+		t.Error("expected .gitignore to be read in a linked worktree")
+	}
+}
+
+func TestGitignoreCacheReuseAndInvalidate(t *testing.T) {
+	dir := writeGitRepo(t, map[string]string{".gitignore": "before/\n"})
+
+	m, err := NewWithOptions(dir, Options{Gitignore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.ShouldIgnoreDir("before") {
+		t.Fatal("expected the initial pattern to apply")
+	}
+
+	// Rewrite within the TTL: the cached scan is reused, so the new pattern
+	// must not be visible yet. This is what keeps a findings run from walking
+	// the tree once per analyser.
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("after/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err = NewWithOptions(dir, Options{Gitignore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.ShouldIgnoreDir("before") || m.ShouldIgnoreDir("after") {
+		t.Error("expected the cached scan to be reused within the TTL")
+	}
+
+	InvalidateGitignoreCache()
+	m, err = NewWithOptions(dir, Options{Gitignore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.ShouldIgnoreDir("before") || !m.ShouldIgnoreDir("after") {
+		t.Error("expected InvalidateGitignoreCache to force a re-read")
+	}
+}
+
+func TestGitignoreCacheIsPerRoot(t *testing.T) {
+	a := writeGitRepo(t, map[string]string{".gitignore": "only-a/\n"})
+	b := writeGitRepo(t, map[string]string{".gitignore": "only-b/\n"})
+
+	ma, err := NewWithOptions(a, Options{Gitignore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mb, err := NewWithOptions(b, Options{Gitignore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !ma.ShouldIgnoreDir("only-a") || ma.ShouldIgnoreDir("only-b") {
+		t.Error("first root picked up the wrong cache entry")
+	}
+	if !mb.ShouldIgnoreDir("only-b") || mb.ShouldIgnoreDir("only-a") {
+		t.Error("second root picked up the wrong cache entry")
+	}
+}
+
+func TestRootPathNeverIgnored(t *testing.T) {
+	// filepath.Rel(root, root) yields "." — if that were treated as a match,
+	// a walk would skip the entire project.
+	m := NewFromDefaults()
+	for _, p := range []string{"", ".", "./"} {
+		if m.ShouldIgnoreDir(p) {
+			t.Errorf("ShouldIgnoreDir(%q) = true, want false", p)
+		}
+	}
+
+	root := "/project"
+	skip, _ := m.WalkFunc(root)(root, &fakeFileInfo{name: "project", dir: true})
+	if skip {
+		t.Error("expected WalkFunc not to skip the project root itself")
+	}
+}
+
+func TestWalkFuncUnrelatedPath(t *testing.T) {
+	// A path that is not under projectRoot cannot be made relative; the raw
+	// path is matched instead of silently ignoring everything.
+	m := NewFromDefaults()
+	shouldSkip := m.WalkFunc("relative-root")
+
+	skip, _ := shouldSkip("/elsewhere/node_modules", &fakeFileInfo{name: "node_modules", dir: true})
+	if !skip {
+		t.Error("expected the fallback to still match on the raw path")
+	}
+}
+
+func TestNewEmptyIgnoresNothing(t *testing.T) {
+	m := NewEmpty()
+	for _, p := range []string{"node_modules", ".git", "vendor"} {
+		if m.ShouldIgnoreDir(p) {
+			t.Errorf("NewEmpty should ignore nothing, but ignored %q", p)
+		}
+	}
+	if m.ShouldIgnoreFile("api.pb.go") {
+		t.Error("NewEmpty should not ignore generated files either")
+	}
+}
+
+func TestUnreadableAideignoreErrors(t *testing.T) {
+	// A .aideignore that cannot be read is a real misconfiguration and must
+	// surface, unlike a missing one. A directory in its place reads as EISDIR.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, IgnoreFileName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := NewWithOptions(dir, Options{}); err == nil {
+		t.Error("expected an unreadable .aideignore to surface an error")
+	}
+}

--- a/aide/pkg/aideignore/aideignore_test.go
+++ b/aide/pkg/aideignore/aideignore_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/jmylchreest/aide/aide/pkg/config"
 )
 
 func TestBuiltinDefaults(t *testing.T) {
@@ -76,9 +78,7 @@ func TestDirOnlyPattern(t *testing.T) {
 }
 
 func TestNegation(t *testing.T) {
-	m := &Matcher{}
-	m.rules = append(m.rules, parsePattern("*.pb.go"))
-	m.rules = append(m.rules, parsePattern("!important.pb.go"))
+	m := newFromPatternStrings("*.pb.go", "!important.pb.go")
 
 	if !m.ShouldIgnoreFile("foo.pb.go") {
 		t.Error("expected foo.pb.go to be ignored")
@@ -89,8 +89,7 @@ func TestNegation(t *testing.T) {
 }
 
 func TestAnchoredPattern(t *testing.T) {
-	m := &Matcher{}
-	m.rules = append(m.rules, parsePattern("/rootfile.txt"))
+	m := newFromPatternStrings("/rootfile.txt")
 
 	if !m.ShouldIgnoreFile("rootfile.txt") {
 		t.Error("expected anchored pattern to match root file")
@@ -101,8 +100,7 @@ func TestAnchoredPattern(t *testing.T) {
 }
 
 func TestUnanchoredPattern(t *testing.T) {
-	m := &Matcher{}
-	m.rules = append(m.rules, parsePattern("*.log"))
+	m := newFromPatternStrings("*.log")
 
 	// Should match at any depth.
 	if !m.ShouldIgnoreFile("error.log") {
@@ -114,8 +112,7 @@ func TestUnanchoredPattern(t *testing.T) {
 }
 
 func TestDoubleStarPrefix(t *testing.T) {
-	m := &Matcher{}
-	m.rules = append(m.rules, parsePattern("**/test/"))
+	m := newFromPatternStrings("**/test/")
 
 	if !m.ShouldIgnoreDir("test") {
 		t.Error("expected **/test/ to match top-level test dir")
@@ -267,8 +264,7 @@ func (f *fakeFileInfo) Sys() any           { return nil }
 func TestAnchoredDirChildPaths(t *testing.T) {
 	// An anchored dir-only pattern like "packages/opencode-plugin/src/"
 	// should match files inside that directory, not just the directory itself.
-	m := &Matcher{}
-	m.rules = append(m.rules, parsePattern("packages/opencode-plugin/src/"))
+	m := newFromPatternStrings("packages/opencode-plugin/src/")
 
 	// Should match the directory itself.
 	if !m.ShouldIgnoreDir("packages/opencode-plugin/src") {
@@ -315,5 +311,171 @@ func TestUnanchoredDirChildPaths(t *testing.T) {
 	// Vendor at root.
 	if !m.ShouldIgnoreFile("vendor/github.com/foo/bar.go") {
 		t.Error("expected unanchored dir pattern to match file inside vendor")
+	}
+}
+
+// writeGitRepo creates a directory that looks enough like a worktree root for
+// the gitignore layer to engage, with the given files written relative to it.
+func writeGitRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range files {
+		full := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	InvalidateGitignoreCache()
+	return dir
+}
+
+func TestGitignoreLayer(t *testing.T) {
+	dir := writeGitRepo(t, map[string]string{
+		".gitignore": ".playwright-mcp/\ndesign/\n*.tmp\n",
+	})
+
+	m, err := NewWithOptions(dir, Options{Gitignore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !m.ShouldIgnoreDir(".playwright-mcp") {
+		t.Error("expected gitignored directory to be ignored")
+	}
+	if !m.ShouldIgnoreFile(".playwright-mcp/page-2026-07-21.yml") {
+		t.Error("expected file inside a gitignored directory to be ignored")
+	}
+	if !m.ShouldIgnoreFile("design/notes.md") {
+		t.Error("expected file inside gitignored design/ to be ignored")
+	}
+	if !m.ShouldIgnoreFile("scratch.tmp") {
+		t.Error("expected *.tmp from .gitignore to be ignored")
+	}
+	if m.ShouldIgnoreFile("main.go") {
+		t.Error("expected an untracked-by-pattern source file to be scanned")
+	}
+}
+
+func TestGitignoreLayerDisabled(t *testing.T) {
+	dir := writeGitRepo(t, map[string]string{
+		".gitignore": ".playwright-mcp/\n",
+	})
+
+	m, err := NewWithOptions(dir, Options{Gitignore: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m.ShouldIgnoreDir(".playwright-mcp") {
+		t.Error("expected gitignore rules to be skipped when the option is off")
+	}
+	// Builtins must still apply.
+	if !m.ShouldIgnoreDir("node_modules") {
+		t.Error("expected builtins to still apply with the gitignore layer off")
+	}
+}
+
+func TestGitignoreNestedDomain(t *testing.T) {
+	// A pattern in docs/.gitignore is scoped to docs/ — flattening the
+	// patterns into one root-level list would wrongly ignore build/ elsewhere.
+	dir := writeGitRepo(t, map[string]string{
+		"docs/.gitignore": "/generated/\n",
+	})
+
+	m, err := NewWithOptions(dir, Options{Gitignore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !m.ShouldIgnoreDir("docs/generated") {
+		t.Error("expected nested .gitignore to ignore within its own directory")
+	}
+	if m.ShouldIgnoreDir("generated") {
+		t.Error("expected nested .gitignore pattern NOT to escape its directory")
+	}
+}
+
+func TestAideignoreOverridesGitignore(t *testing.T) {
+	// .aideignore is layered last, so a "!" line there wins over .gitignore.
+	dir := writeGitRepo(t, map[string]string{
+		".gitignore":  "generated/\n",
+		".aideignore": "!generated/schema.go\n",
+	})
+
+	m, err := NewWithOptions(dir, Options{Gitignore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !m.ShouldIgnoreFile("generated/other.go") {
+		t.Error("expected gitignored file to stay ignored")
+	}
+	if m.ShouldIgnoreFile("generated/schema.go") {
+		t.Error("expected .aideignore negation to re-include the file")
+	}
+}
+
+func TestGitignoreSkippedOutsideRepo(t *testing.T) {
+	// No .git — a stray .gitignore must not engage the layer, and the walk
+	// that would discover it is skipped entirely.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("secret/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	InvalidateGitignoreCache()
+
+	m, err := NewWithOptions(dir, Options{Gitignore: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m.ShouldIgnoreDir("secret") {
+		t.Error("expected .gitignore to be skipped when the root is not a worktree")
+	}
+}
+
+func TestNewHonoursConfig(t *testing.T) {
+	dir := writeGitRepo(t, map[string]string{
+		".gitignore": "artifacts/\n",
+	})
+
+	off := false
+	config.Set(&config.Config{Code: config.CodeConfig{RespectGitignore: &off}})
+	t.Cleanup(func() { config.Set(nil) })
+
+	m, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.ShouldIgnoreDir("artifacts") {
+		t.Error("expected code.respect_gitignore=false to disable the layer")
+	}
+
+	on := true
+	config.Set(&config.Config{Code: config.CodeConfig{RespectGitignore: &on}})
+	InvalidateGitignoreCache()
+
+	m, err = New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.ShouldIgnoreDir("artifacts") {
+		t.Error("expected code.respect_gitignore=true to enable the layer")
+	}
+}
+
+func TestUnloadedConfigDefaultsGitignoreOn(t *testing.T) {
+	// config.Get() returns a zero Config before Load runs; the *bool must
+	// still resolve to on so a fresh process does not silently scan
+	// gitignored paths.
+	config.Set(nil)
+	if !config.Get().Code.RespectGitignoreEnabled() {
+		t.Error("expected RespectGitignore to default on with no config loaded")
 	}
 }

--- a/aide/pkg/config/config.go
+++ b/aide/pkg/config/config.go
@@ -213,6 +213,22 @@ type CodeConfig struct {
 	// StoreSync makes code-store opening synchronous (default false =
 	// lazy-init in the background). AIDE_CODE_STORE_SYNC=1.
 	StoreSync bool `koanf:"store_sync"`
+	// RespectGitignore layers the repository's own ignore rules (.gitignore
+	// files plus .git/info/exclude) into the aideignore matcher, between the
+	// built-in defaults and .aideignore. Without it the analysers scan paths
+	// git ignores unless .aideignore repeats the pattern. nil = on; set
+	// code.respect_gitignore=false or AIDE_CODE_RESPECT_GITIGNORE=0 to scan
+	// gitignored paths anyway.
+	//
+	// Pointer rather than plain bool because Get() returns a zero-valued
+	// Config when Load has not run, and a default-on feature must not read as
+	// off in that window. Resolve it with RespectGitignoreEnabled.
+	RespectGitignore *bool `koanf:"respect_gitignore"`
+}
+
+// RespectGitignoreEnabled resolves RespectGitignore, defaulting to on.
+func (c CodeConfig) RespectGitignoreEnabled() bool {
+	return resolveBool(c.RespectGitignore, true)
 }
 
 // PprofConfig groups pprof http server tunables (AIDE_PPROF_*).

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -14,6 +14,7 @@ AIDE is configured through environment variables. All variables are optional.
 | `AIDE_FORCE_INIT=1`              | Force initialization in non-git directories      |
 | `AIDE_CODE_WATCH=0`              | Disable file watching for auto-reindex (default: on; equivalent to `code.watch` in `.aide/config/aide.json`) |
 | `AIDE_CODE_WATCH_DELAY=30s`      | Delay before re-indexing after file changes      |
+| `AIDE_CODE_RESPECT_GITIGNORE=0`  | Scan paths your `.gitignore` excludes (default: on; equivalent to `code.respect_gitignore` in `.aide/config/aide.json`). See [File Exclusions](#file-exclusions) |
 | `AIDE_INDEX_NON_VCS=1`           | Allow watcher/indexing in non-VCS dirs (default: refuse) |
 | `AIDE_INDEX_WORKERS=N`           | Parallel parser workers for code indexing (default: NumCPU, capped at 32) |
 | `AIDE_MEMORY_INJECT=0`           | Disable memory injection                         |
@@ -130,6 +131,7 @@ Project-level settings can be stored in `.aide/config/aide.json`:
 | `findings.clones.windowSize`    | 50      | Sliding window size in tokens for detection  |
 | `findings.clones.minLines`      | 6       | Minimum clone size in lines to report        |
 
+| `code.respect_gitignore`        | true    | Apply the repo's `.gitignore` rules to analysis — see [File Exclusions](#file-exclusions) |
 | `cleanup.enabled`               | true    | Master switch for retention pruning (daemon loop + session-init sweep) |
 | `cleanup.observe_max_age`       | 2160h   | TTL for observe/telemetry events, 90 days (`0` = keep forever) |
 | `cleanup.task_max_age`          | 2160h   | TTL for completed tasks, 90 days (pending/claimed are never pruned) |
@@ -184,7 +186,30 @@ vendor/
 !vendor/important.go
 ```
 
-Built-in defaults already exclude common generated files, lock files, build artifacts, and directories like `node_modules/`, `.git/`, `vendor/`, etc.
+Patterns are applied in three layers, each able to override the one below it:
+
+1. **Built-in defaults** — common generated files, lock files, build artifacts,
+   and directories like `node_modules/`, `.git/`, `vendor/`.
+2. **Your `.gitignore`** — every `.gitignore` in the tree plus
+   `.git/info/exclude`, on by default. Anything git ignores is excluded from
+   analysis too, so build output and scratch directories don't have to be
+   listed twice. Turn it off with `code.respect_gitignore=false` (or
+   `AIDE_CODE_RESPECT_GITIGNORE=0`) when you deliberately analyse untracked
+   files.
+3. **`.aideignore`** — project overrides, applied last. A `!` line here
+   re-includes something the layers below excluded:
+
+   ```gitignore
+   # .gitignore excludes all of generated/, but this one is worth analysing
+   !generated/schema.go
+   ```
+
+All three use git's own pattern parser, so semantics match `git check-ignore`:
+last match wins, `!` re-includes, a trailing `/` matches directories only, `**`
+spans path segments, and a leading `/` anchors to the directory holding the
+file. Your global (`core.excludesfile`) and system ignore files are
+deliberately **not** consulted — they differ per machine, which would make the
+same repository produce different findings on different checkouts.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What

Every findings analyser, the grammar scan, and the survey built their ignore matcher from built-in defaults plus `.aideignore` only — `.gitignore` was never consulted. Anything git ignores was still walked and analysed unless `.aideignore` happened to repeat the pattern.

In this repo that meant `.playwright-mcp/` (9 stray browser-session artifacts) and the local-only `design/` notes were being scanned.

## How

Two changes that turned out to be one change:

1. **Add a `.gitignore` layer** — every `.gitignore` in the tree plus `.git/info/exclude`, via go-git's `gitignore.ReadPatterns`. Gated by `code.respect_gitignore` / `AIDE_CODE_RESPECT_GITIGNORE`, on by default.

2. **Replace the hand-rolled pattern engine with go-git's.** Rather than run a second matcher alongside the existing one, all three sources are now parsed by `gitignore.ParsePattern` and fed to a single `gitignore.NewMatcher`, ordered builtins → `.gitignore` → `.aideignore`.

That ordering is the whole precedence design: go-git's matcher walks the pattern slice in reverse and stops at the first match, so appending `.aideignore` last is all it takes for a `!` line there to re-include something a `.gitignore` excluded. Its `dirOnly` handling also covers the parent-directory case (`vendor/` ignoring `vendor/foo/bar.go`) that `ShouldIgnore` previously reimplemented with a recursive walk up the path.

Net: `rule`, `parsePattern`, `match`, `matchGlob`, `matchPathSuffix`, `matchDoublestar`, and `basename` are gone — ~150 lines replaced by one `m.matcher.Match(strings.Split(path, "/"), isDir)`, and the semantics are now git's rather than an approximation of them.

## Effect

Against this repo, with the artifacts still on disk:

| path | before | after |
| --- | --- | --- |
| `.playwright-mcp/` | scanned | ignored |
| `.playwright-mcp/page-*.yml` | scanned | ignored |
| `design/module-map-*.md` | scanned | ignored |
| `docs/build/index.html` | ignored | ignored |
| `aide/pkg/.../aideignore.go` | scanned | scanned |

`docs/build/` was already caught by the `build/` builtin — included as the control.

## Decisions worth reviewing

- **`aideignore` now imports `config`.** That's what makes the flag work at all 8 `New()` call sites without threading a bool through `pkg/survey`, `pkg/grammar`, and `pkg/findings`. No import cycle (config is stdlib + koanf only), and it matches the codebase's `config.Get()` singleton style — but it does couple a leaf utility to config. `NewWithOptions` stays config-free.
- **`RespectGitignore` is `*bool`.** `config.Get()` returns a zero `Config` before `Load()` runs, so a plain `bool` would read as *off* in that window — the opposite of the intended default. Resolved via `RespectGitignoreEnabled()`, following the existing `ShareTypePolicy` idiom.
- **Global (`core.excludesfile`) and system ignore files are deliberately not read.** They differ per machine, so honouring them would let the same tree produce different findings on different checkouts.
- **30s TTL memo on the gitignore scan**, since `New()` is called once per analyser. `InvalidateGitignoreCache()` is exported for an explicit flush.

## Second commit: a bug the first one exposed

`aide config get code.respect_gitignore` reported `false` for an unset key. `ptrBoolDefault` was a hand-written switch over the four `share.*` keys with `default: return false` — its own comment said "any other `*bool` key (none today)". This was the first one, so the CLI reported the opposite of the actual behaviour. `aide config show` omitted the key entirely, since that section's field list is also hand-written.

Both fixed, plus `TestPtrBoolDefaultsCoverSchema` cross-checks the switch against `config.Schema()` so the next `*bool` added to the schema fails the build instead of silently reporting the wrong default.

## Configuring it

```bash
aide config set code.respect_gitignore false           # project
aide config set --global code.respect_gitignore false  # user-global
AIDE_CODE_RESPECT_GITIGNORE=0 ...                      # env, wins over both
aide config unset code.respect_gitignore               # back to default (true)
```

Verified end to end against a scratch project, including env-over-file precedence and `--all` attributing an unset key to `default`.

## Tests

All 13 pre-existing `aideignore` tests pass with assertions unchanged — only the three that poked `m.rules`/`parsePattern` were rewritten onto a `newFromPatternStrings` helper. Added 7 more covering nested-`.gitignore` domain scoping, `.aideignore` overriding `.gitignore`, the option off, non-worktree roots, and the config plumbing. Full `go test ./...` green after rebasing onto `main`.

## Docs

`docs/docs/getting-started/configuration.md` — env var table, project settings table, and **File Exclusions** rewritten from a single `.aideignore` paragraph into the three-layer model.

`docs/versioned_docs/` intentionally untouched: those are release snapshots generated by `make release` / `docs-version.yml`.