### PR TITLE
fix(findings): bootstrap empty code index before deadcode analysis

### DIFF
--- a/aide/cmd/aide/cmd_code.go
+++ b/aide/cmd/aide/cmd_code.go
@@ -514,7 +514,7 @@ func (idx *Indexer) IndexFile(filePath string) (int, error) {
 type ReconcileResult struct {
 	Checked   int // Total entries inspected
 	Removed   int // Entries dropped because the file no longer exists on disk
-	Refreshed int // Entries re-indexed because mtime advanced
+	Refreshed int // Entries re-indexed because mtime advanced, or newly indexed during an empty-index bootstrap
 	Errors    int // Stat / index failures (skipped, not fatal)
 }
 
@@ -585,7 +585,51 @@ func (idx *Indexer) Reconcile() (ReconcileResult, error) {
 	}
 
 	idx.sweepOrphans(infos, ignore, &res)
+
+	// Bootstrap an empty index. Reconcile otherwise only refreshes files it
+	// already knows about, so a fresh store (nothing ever indexed) would stay
+	// empty and every code-index-dependent analyzer (deadcode, modules) would
+	// hard-fail with "code index is empty". Populate from the working tree
+	// when there is nothing to reconcile against.
+	if len(infos) == 0 {
+		if err := idx.indexTree(ignore, &res); err != nil {
+			return res, err
+		}
+	}
+
 	return res, nil
+}
+
+// indexTree walks the project root and indexes every supported, non-ignored
+// file. It is the empty-index bootstrap half of Reconcile: the only way a
+// store with no entries can be made usable without a manual `aide code index`.
+func (idx *Indexer) indexTree(ignore *aideignore.Matcher, res *ReconcileResult) error {
+	shouldSkip := ignore.WalkFunc(idx.rootDir)
+	err := filepath.Walk(idx.rootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if skip, skipDir := shouldSkip(path, info); skip {
+			if skipDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !code.SupportedFile(path) {
+			return nil
+		}
+		if _, err := idx.IndexFile(path); err != nil {
+			res.Errors++
+			return nil
+		}
+		res.Checked++
+		res.Refreshed++
+		return nil
+	})
+	return err
 }
 
 // sweepOrphans handles the post-fileinfo cleanup pass: corrupt rows (empty

--- a/aide/cmd/aide/cmd_code_test.go
+++ b/aide/cmd/aide/cmd_code_test.go
@@ -66,3 +66,48 @@ func TestIndexerReconcile_RemovesOrphans(t *testing.T) {
 		t.Errorf("real.go should still be indexed: %v", err)
 	}
 }
+
+// TestIndexerReconcile_BootstrapsEmptyIndex verifies that Reconcile populates
+// a store with no entries at all by walking the working tree. Without this,
+// a fresh store surfaces as "code index is empty" to code-index-dependent
+// analyzers (deadcode, modules) even though the reconciler ran.
+func TestIndexerReconcile_BootstrapsEmptyIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+	aideDir := filepath.Join(tmpDir, ".aide", "memory")
+	if err := os.MkdirAll(aideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(aideDir, "memory.db")
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc Foo() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	indexPath, searchPath := getCodeStorePaths(dbPath)
+	cs, err := store.NewCodeStore(indexPath, searchPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	idx := NewIndexerFromStore(cs, newGrammarLoader(dbPath, nil), tmpDir)
+
+	res, err := idx.Reconcile()
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.Refreshed == 0 {
+		t.Errorf("expected bootstrap to index files, got %+v", res)
+	}
+
+	stats, err := cs.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Symbols == 0 {
+		t.Errorf("expected symbols after bootstrap, got %+v", stats)
+	}
+	if _, err := cs.GetFileInfo("main.go"); err != nil {
+		t.Errorf("main.go should be indexed: %v", err)
+	}
+}

--- a/aide/cmd/aide/cmd_daemon.go
+++ b/aide/cmd/aide/cmd_daemon.go
@@ -163,11 +163,21 @@ func cmdDaemon(dbPath string, args []string) error {
 	}
 
 	// Create gRPC server
-	server := grpcapi.NewServer(st, dbPath, socketPath, newGrammarLoader(dbPath, nil))
+	loader := newGrammarLoader(dbPath, nil)
+	server := grpcapi.NewServer(st, dbPath, socketPath, loader)
 
 	// Set code store if available
 	if codeStore != nil {
 		server.SetCodeStore(codeStore)
+		// Install the code reconciler so project-wide analyzers (deadcode,
+		// modules) refresh the index — and bootstrap it when empty — before
+		// they run. Without this, reconcileCode() is a no-op for the standalone
+		// daemon and an empty index surfaces as "code index is empty".
+		indexer := NewIndexerFromStore(codeStore, loader, store.ProjectRootFromDB(dbPath))
+		server.SetCodeReconciler(func() (int, int, error) {
+			res, err := indexer.Reconcile()
+			return res.Removed, res.Refreshed, err
+		})
 	}
 
 	// Set findings store if available


### PR DESCRIPTION
## Problem

`aide findings run all` (or `run deadcode`) aborts at the deadcode analyzer with:

```
deadcode analyser failed: rpc error: code = Unknown desc = code index is empty — run 'aide code index' first
```

…even after a successful `aide code index`. The other analyzers (complexity, coupling, secrets, clones, security, todos) run fine — deadcode is just the first one that requires the code index.

## Root cause

`RunDeadCodeAnalysis` calls `reconcileCode()` before checking `stats.Symbols`, but that "reconcile before analyze" safety net is broken in two ways:

1. **`Indexer.Reconcile()` can't bootstrap an empty index** — it only walks *already-indexed* `FileInfo` entries (removing orphans / refreshing stale mtimes). A genuinely empty store stays empty no matter how often reconcile runs.
2. **The standalone daemon never installs the reconciler** — `SetCodeReconciler` was only called by the MCP server (`startCodeReconciler`). `cmdDaemon` set the code store but never the reconciler, so `reconcileCode()` was a no-op for daemon users.

So whenever the daemon's code store was empty (fresh clone, `code clear`, index built before the daemon started), deadcode hard-failed and nothing auto-healed it.

## Fix

- `Indexer.Reconcile()` now bootstraps an empty index via a new `indexTree` helper: when `ListAllFileInfo()` returns nothing, it walks the project root (respecting `.aideignore` and `code.SupportedFile`) and indexes every file.
- `cmdDaemon` installs a code reconciler mirroring the MCP server, so `reconcileCode()` is no longer a no-op there.

## Testing

- Reproduced the exact failure against an empty-store daemon, then confirmed the fix: the daemon logs `reconcile before deadcode: removed 0, refreshed 1296` and `findings run deadcode` completes (`Checked 3599 symbols …`).
- Added `TestIndexerReconcile_BootstrapsEmptyIndex`.
- `go build ./...`, `go vet ./cmd/aide/`, and `go test ./cmd/aide/ -count=1` all pass.