### PR TITLE
fix(grammar): isolate the pack registry in tests that assert embedded packs

### DIFF
--- a/aide/pkg/grammar/comments_test.go
+++ b/aide/pkg/grammar/comments_test.go
@@ -3,6 +3,8 @@ package grammar
 import "testing"
 
 func TestIsCommentLine_PackDriven(t *testing.T) {
+	isolatePackRegistry(t)
+
 	cases := []struct {
 		line string
 		lang string
@@ -41,6 +43,8 @@ func TestIsCommentLine_NoCommentsLanguage(t *testing.T) {
 }
 
 func TestExtractCommentText_PackDriven(t *testing.T) {
+	isolatePackRegistry(t)
+
 	cases := []struct {
 		line string
 		lang string

--- a/aide/pkg/grammar/dynamic_test.go
+++ b/aide/pkg/grammar/dynamic_test.go
@@ -58,6 +58,8 @@ func TestDynamicLoaderRemoveNonexistent(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDynamicPacksMap(t *testing.T) {
+	isolatePackRegistry(t)
+
 	expected := []string{
 		"bash", "clojure", "csharp", "css", "dart", "elixir", "elm", "erlang", "groovy",
 		"haskell", "hcl", "html", "kotlin", "lua", "ocaml", "php", "protobuf", "r",

--- a/aide/pkg/grammar/pack_test.go
+++ b/aide/pkg/grammar/pack_test.go
@@ -7,6 +7,23 @@ import (
 	"testing"
 )
 
+// isolatePackRegistry swaps the process-wide pack registry for a pristine one
+// for the duration of the test. DynamicLoader.Download loads a downloaded
+// pack.json into DefaultPackRegistry(), so the integration tests that install
+// fake grammars leave overridden entries behind. Tests that assert on embedded
+// pack data must not see them — without this they pass on the first pass and
+// fail on the second (go test -count=2, or the -bench measurement run).
+func isolatePackRegistry(t *testing.T) {
+	t.Helper()
+	prev := DefaultPackRegistry()
+	fresh, err := NewPackRegistry()
+	if err != nil {
+		t.Fatalf("NewPackRegistry(): %v", err)
+	}
+	defaultRegistry = fresh
+	t.Cleanup(func() { defaultRegistry = prev })
+}
+
 // allExpectedLanguages lists every language that should have a pack.json.
 var allExpectedLanguages = []string{
 	// 10 embedded (built-in)


### PR DESCRIPTION
The `Benchmark measurement` job has been failing on `main` since the benchmarks landed. It is not the benchmarks — it is test pollution that only shows up when the suite runs more than once in a process.

`go test -bench=. -count=3` runs without `-run`, so the unit tests execute three times in the same binary. From the second pass on:

```
--- FAIL: TestIsCommentLine_PackDriven
    IsCommentLine("-- lua comment", "lua") = false, want true
--- FAIL: TestExtractCommentText_PackDriven
--- FAIL: TestDynamicPacksMap
    DynamicPacks has 26 entries, want 25
```

`DynamicLoader.Download` loads a downloaded `pack.json` into the process-wide `DefaultPackRegistry()` (dynamic.go). The integration tests install fake grammars named `lua`, `ruby`, `php`, `bash`, `kotlin` and `testlang`, so by the second pass lua's pack has been replaced by a stub with no comment delimiters, and `testlang` has joined the dynamic packs. The first pass passes only because these tests happen to run before the integration tests.

This gives the three tests that assert on embedded pack data a pristine registry for their duration, so the suite stops depending on execution order or repetition. The production behaviour — a downloaded pack overriding the embedded one — is unchanged and still covered by the integration tests.

`go test -count=3 ./pkg/grammar/` passes, the full `make bench` command passes (exit 0), and `go test ./...` is clean.

Reproduce the old failure with: `cd aide && go test -count=2 ./pkg/grammar/`

https://claude.ai/code/session_016NN7P32MY5gzfozDUJxScv