### PR TITLE
fix(watcher): index and analyse files the watcher never saw

### DIFF
--- a/aide/cmd/aide/cmd_code.go
+++ b/aide/cmd/aide/cmd_code.go
@@ -514,8 +514,11 @@ func (idx *Indexer) IndexFile(filePath string) (int, error) {
 type ReconcileResult struct {
 	Checked   int // Total entries inspected
 	Removed   int // Entries dropped because the file no longer exists on disk
-	Refreshed int // Entries re-indexed because mtime advanced, or newly indexed during an empty-index bootstrap
+	Refreshed int // Entries re-indexed because mtime advanced, or newly discovered on disk
 	Errors    int // Stat / index failures (skipped, not fatal)
+	// Touched holds the absolute paths this pass indexed or re-indexed, so
+	// the caller can re-run the findings analysers over them.
+	Touched []string
 }
 
 // Reconcile walks the file index and brings it back in sync with the working
@@ -523,7 +526,8 @@ type ReconcileResult struct {
 // now matches an aideignore rule are removed, and stale entries (file mtime
 // newer than the indexed mtime) are re-indexed. Then a second sweep walks
 // every symbol and reference bucket entry to catch orphan rows whose fileinfo
-// was already cleared but whose symbol/reference rows survived.
+// was already cleared but whose symbol/reference rows survived. Finally the
+// working tree is walked to pick up files the index has never seen.
 func (idx *Indexer) Reconcile() (ReconcileResult, error) {
 	span := observe.Start("Indexer.Reconcile", observe.KindSpan).Category("indexer").Subtype("reconcile")
 	defer span.End()
@@ -542,6 +546,11 @@ func (idx *Indexer) Reconcile() (ReconcileResult, error) {
 	ignore, _ := aideignore.New(idx.rootDir)
 	if ignore == nil {
 		ignore = aideignore.NewFromDefaults()
+	}
+
+	known := make(map[string]struct{}, len(infos))
+	for _, info := range infos {
+		known[info.Path] = struct{}{}
 	}
 
 	for _, info := range infos {
@@ -578,6 +587,7 @@ func (idx *Indexer) Reconcile() (ReconcileResult, error) {
 		if !stat.ModTime().Equal(info.ModTime) {
 			if _, ixErr := idx.IndexFile(absPath); ixErr == nil {
 				res.Refreshed++
+				res.Touched = append(res.Touched, absPath)
 			} else {
 				res.Errors++
 			}
@@ -586,24 +596,18 @@ func (idx *Indexer) Reconcile() (ReconcileResult, error) {
 
 	idx.sweepOrphans(infos, ignore, &res)
 
-	// Bootstrap an empty index. Reconcile otherwise only refreshes files it
-	// already knows about, so a fresh store (nothing ever indexed) would stay
-	// empty and every code-index-dependent analyzer (deadcode, modules) would
-	// hard-fail with "code index is empty". Populate from the working tree
-	// when there is nothing to reconcile against.
-	if len(infos) == 0 {
-		if err := idx.indexTree(ignore, &res); err != nil {
-			return res, err
-		}
+	if err := idx.indexTree(ignore, &res, known); err != nil {
+		return res, err
 	}
 
 	return res, nil
 }
 
 // indexTree walks the project root and indexes every supported, non-ignored
-// file. It is the empty-index bootstrap half of Reconcile: the only way a
-// store with no entries can be made usable without a manual `aide code index`.
-func (idx *Indexer) indexTree(ignore *aideignore.Matcher, res *ReconcileResult) error {
+// file not already in known. It is the discovery half of Reconcile: the only
+// way a file the watcher never saw enters the index, and the bootstrap for a
+// store with no entries at all.
+func (idx *Indexer) indexTree(ignore *aideignore.Matcher, res *ReconcileResult, known map[string]struct{}) error {
 	shouldSkip := ignore.WalkFunc(idx.rootDir)
 	err := filepath.Walk(idx.rootDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -621,12 +625,19 @@ func (idx *Indexer) indexTree(ignore *aideignore.Matcher, res *ReconcileResult) 
 		if !code.SupportedFile(path) {
 			return nil
 		}
+		// Already handled by the reconcile loop above.
+		if rel, relErr := filepath.Rel(idx.rootDir, path); relErr == nil {
+			if _, seen := known[rel]; seen {
+				return nil
+			}
+		}
 		if _, err := idx.IndexFile(path); err != nil {
 			res.Errors++
 			return nil
 		}
 		res.Checked++
 		res.Refreshed++
+		res.Touched = append(res.Touched, path)
 		return nil
 	})
 	return err

--- a/aide/cmd/aide/cmd_code_test.go
+++ b/aide/cmd/aide/cmd_code_test.go
@@ -111,3 +111,112 @@ func TestIndexerReconcile_BootstrapsEmptyIndex(t *testing.T) {
 		t.Errorf("main.go should be indexed: %v", err)
 	}
 }
+
+// TestIndexerReconcile_DiscoversUnindexedFiles verifies that Reconcile picks
+// up a file that is on disk but has never been indexed, and reports it in
+// Touched. The watcher can miss a file entirely — one created inside a
+// directory before that directory had an inotify watch — and the per-entry
+// reconcile loop cannot see it, because it only inspects paths that are
+// already index entries. Without this walk such a file stays invisible until
+// someone runs `aide code index` by hand.
+func TestIndexerReconcile_DiscoversUnindexedFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	aideDir := filepath.Join(tmpDir, ".aide", "memory")
+	if err := os.MkdirAll(aideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(aideDir, "memory.db")
+
+	known := filepath.Join(tmpDir, "known.go")
+	if err := os.WriteFile(known, []byte("package main\n\nfunc Known() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	knownStat, err := os.Stat(known)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	indexPath, searchPath := getCodeStorePaths(dbPath)
+	cs, err := store.NewCodeStore(indexPath, searchPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	// Already indexed and unchanged: must not be re-indexed or reported.
+	if err := cs.SetFileInfo(&code.FileInfo{Path: "known.go", ModTime: knownStat.ModTime()}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Never indexed, in a subdirectory — the shape a missed watch produces.
+	missedDir := filepath.Join(tmpDir, "pkg")
+	if err := os.MkdirAll(missedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(missedDir, "missed.go"), []byte("package pkg\n\nfunc Missed() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := NewIndexerFromStore(cs, newGrammarLoader(dbPath, nil), tmpDir)
+
+	res, err := idx.Reconcile()
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if _, err := cs.GetFileInfo(filepath.Join("pkg", "missed.go")); err != nil {
+		t.Errorf("pkg/missed.go should have been discovered: %v", err)
+	}
+	if res.Refreshed != 1 {
+		t.Errorf("expected 1 refreshed (the discovered file), got %d (%+v)", res.Refreshed, res)
+	}
+	if len(res.Touched) != 1 {
+		t.Fatalf("expected 1 touched path, got %v", res.Touched)
+	}
+	if got := filepath.Base(res.Touched[0]); got != "missed.go" {
+		t.Errorf("Touched = %v, want the discovered file", res.Touched)
+	}
+}
+
+// TestIndexerReconcile_ReportsRefreshedInTouched verifies that a stale entry
+// re-indexed by Reconcile is reported in Touched, so the caller can re-run the
+// findings analysers over it. Healing the index without re-analysing leaves
+// findings stale for exactly the files that changed.
+func TestIndexerReconcile_ReportsRefreshedInTouched(t *testing.T) {
+	tmpDir := t.TempDir()
+	aideDir := filepath.Join(tmpDir, ".aide", "memory")
+	if err := os.MkdirAll(aideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(aideDir, "memory.db")
+
+	stale := filepath.Join(tmpDir, "stale.go")
+	if err := os.WriteFile(stale, []byte("package main\n\nfunc Stale() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	indexPath, searchPath := getCodeStorePaths(dbPath)
+	cs, err := store.NewCodeStore(indexPath, searchPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	// Indexed mtime predates the file on disk, so the entry is stale.
+	if err := cs.SetFileInfo(&code.FileInfo{Path: "stale.go", ModTime: time.Now().Add(-time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := NewIndexerFromStore(cs, newGrammarLoader(dbPath, nil), tmpDir)
+
+	res, err := idx.Reconcile()
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.Refreshed != 1 {
+		t.Errorf("expected 1 refreshed, got %d (%+v)", res.Refreshed, res)
+	}
+	if len(res.Touched) != 1 || filepath.Base(res.Touched[0]) != "stale.go" {
+		t.Errorf("Touched = %v, want the refreshed file", res.Touched)
+	}
+}

--- a/aide/cmd/aide/cmd_mcp.go
+++ b/aide/cmd/aide/cmd_mcp.go
@@ -400,7 +400,38 @@ func (s *MCPServer) startCodeReconciler(dbPath string) {
 			mcpLog.Printf("startup reconcile: checked %d, removed %d, refreshed %d, errors %d",
 				res.Checked, res.Removed, res.Refreshed, res.Errors)
 		}
+
+		// Analyse what reconcile indexed, or the index heals but findings don't.
+		if len(res.Touched) == 0 {
+			return
+		}
+		runner := s.awaitFindingsRunner()
+		if runner == nil {
+			return
+		}
+		files := make(map[string]fsnotify.Op, len(res.Touched))
+		for _, p := range res.Touched {
+			files[p] = fsnotify.Write
+		}
+		mcpLog.Printf("startup reconcile: analysing %d reconciled file(s)", len(files))
+		runner.OnChanges(files)
 	}()
+}
+
+// awaitFindingsRunner waits for startCodeWatcher to construct the findings
+// runner — both start as independent goroutines. Returns nil when the watcher
+// is disabled or has no findings store.
+func (s *MCPServer) awaitFindingsRunner() *findings.Runner {
+	for i := 0; i < DefaultMCPPollCount; i++ {
+		s.unifiedWatcherMu.Lock()
+		r := s.findingsRunner
+		s.unifiedWatcherMu.Unlock()
+		if r != nil {
+			return r
+		}
+		time.Sleep(DefaultMCPPollInterval)
+	}
+	return nil
 }
 
 // startCodeWatcher launches the file watcher in the background.
@@ -455,16 +486,17 @@ func (s *MCPServer) startCodeWatcher(dbPath string, cfg *mcpConfig) {
 		// Build handler list — always include code indexer, add findings runner if store is available
 		handlers := []watcher.FileChangeHandler{codeHandler}
 
+		// One matcher for the whole pipeline: the watcher decides what to
+		// watch with it, the analysers filter with it.
+		projectRoot := store.ProjectRootFromDB(dbPath)
+		ignore, err := aideignore.New(projectRoot)
+		if err != nil {
+			mcpLog.Printf("WARNING: failed to load .aideignore: %v (using defaults)", err)
+			ignore = aideignore.NewFromDefaults()
+		}
+
 		var findingsRunner *findings.Runner
 		if s.findingsStore != nil {
-			// Load .aideignore from project root for findings filtering.
-			projectRoot := store.ProjectRootFromDB(dbPath)
-			ignore, err := aideignore.New(projectRoot)
-			if err != nil {
-				mcpLog.Printf("WARNING: failed to load .aideignore: %v (using defaults)", err)
-				ignore = aideignore.NewFromDefaults()
-			}
-
 			// Load analyser thresholds from .aide/config/aide.json.
 			fcfg := loadFindingsConfig(projectRoot)
 
@@ -505,12 +537,12 @@ func (s *MCPServer) startCodeWatcher(dbPath string, cfg *mcpConfig) {
 
 		// Register grammar install callback: when a new grammar is downloaded,
 		// re-scan the project tree for files matching its extensions.
-		root := store.ProjectRootFromDB(dbPath)
+		root := projectRoot
 		s.grammarLoader.SetOnInstall(func(name string) {
 			// Run re-scan in a goroutine to avoid blocking the parse call
 			// that triggered the download.
 			go func() {
-				rescanForGrammar(name, indexer, findingsRunner, root)
+				rescanForGrammar(name, indexer, findingsRunner, root, ignore)
 				// Mark re-scan complete in the manifest so it won't be
 				// re-triggered on restart.
 				s.grammarLoader.MarkRescanComplete(name)
@@ -519,8 +551,10 @@ func (s *MCPServer) startCodeWatcher(dbPath string, cfg *mcpConfig) {
 
 		w, err := watcher.New(watcher.Config{
 			Paths:         watchPaths,
+			ProjectRoot:   projectRoot,
 			DebounceDelay: debounceDelay,
 			FileFilter:    code.SupportedFile,
+			Ignore:        ignore,
 		}, handlers...)
 		if err != nil {
 			mcpLog.Printf("WARNING: failed to create unified watcher: %v", err)
@@ -556,7 +590,7 @@ func (s *MCPServer) startCodeWatcher(dbPath string, cfg *mcpConfig) {
 			mcpLog.Printf("found %d grammar(s) with pending re-scan: %s", len(pending), strings.Join(pending, ", "))
 			go func() {
 				for _, name := range pending {
-					rescanForGrammar(name, indexer, findingsRunner, root)
+					rescanForGrammar(name, indexer, findingsRunner, root, ignore)
 					s.grammarLoader.MarkRescanComplete(name)
 				}
 			}()
@@ -600,7 +634,7 @@ func (h *codeIndexHandler) OnChanges(files map[string]fsnotify.Op) {
 // the given grammar's extensions. This is called after a grammar is newly
 // installed to pick up files that were previously skipped (zero symbols).
 // It also notifies the findings runner if available.
-func rescanForGrammar(name string, indexer *Indexer, runner *findings.Runner, root string) {
+func rescanForGrammar(name string, indexer *Indexer, runner *findings.Runner, root string, ignore *aideignore.Matcher) {
 	pack := grammar.DefaultPackRegistry().Get(name)
 	if pack == nil {
 		return
@@ -627,15 +661,18 @@ func rescanForGrammar(name string, indexer *Indexer, runner *findings.Runner, ro
 		findingsFiles = make(map[string]fsnotify.Op)
 	}
 
+	shouldSkip := ignore.WalkFunc(root)
 	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil // skip errors
 		}
-		if info.IsDir() {
-			dirName := info.Name()
-			if watcher.DefaultSkipDirs[dirName] || (len(dirName) > 1 && dirName[0] == '.') {
+		if skip, skipDir := shouldSkip(path, info); skip {
+			if skipDir {
 				return filepath.SkipDir
 			}
+			return nil
+		}
+		if info.IsDir() {
 			return nil
 		}
 

--- a/aide/pkg/aideignore/aideignore.go
+++ b/aide/pkg/aideignore/aideignore.go
@@ -64,6 +64,20 @@ var BuiltinDefaults = []string{
 	".nuxt/",
 	"coverage/",
 	".cache/",
+	".yarn/cache/",
+	".yarn/unplugged/",
+	".pnpm-store/",
+	".turbo/",
+	".nx/",
+	".parcel-cache/",
+	".nyc_output/",
+	".svelte-kit/",
+	".astro/",
+	".angular/",
+	".docusaurus/",
+	".vercel/",
+	".netlify/",
+	".serverless/",
 
 	// ── Python ───────────────────────────────────────────────────────
 	"__pycache__/",
@@ -72,6 +86,8 @@ var BuiltinDefaults = []string{
 	".tox/",
 	".mypy_cache/",
 	".pytest_cache/",
+	".ruff_cache/",
+	".ipynb_checkpoints/",
 	"*.egg-info/",
 	"site-packages/",
 
@@ -114,6 +130,17 @@ var BuiltinDefaults = []string{
 
 	// ── Swift ────────────────────────────────────────────────────────
 	".build/",
+
+	// ── Dart / Flutter ───────────────────────────────────────────────
+	".dart_tool/",
+
+	// ── Haskell ──────────────────────────────────────────────────────
+	".stack-work/",
+
+	// ── Infrastructure / environment tooling ─────────────────────────
+	".terraform/",
+	".terragrunt-cache/",
+	".direnv/",
 
 	// ── IDE / Editor ─────────────────────────────────────────────────
 	".idea/",

--- a/aide/pkg/watcher/watcher.go
+++ b/aide/pkg/watcher/watcher.go
@@ -11,97 +11,25 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/jmylchreest/aide/aide/pkg/aideignore"
 )
 
 var watchLog = log.New(os.Stderr, "[aide:watcher] ", log.Ltime)
 
 const DefaultDebounceDelay = 30 * time.Second
 
-// DefaultSkipDirs contains directories to skip during file watching.
-// Organized by language/ecosystem but applied universally for simplicity.
-var DefaultSkipDirs = map[string]bool{
-	// Version control
-	".git": true, ".svn": true, ".hg": true,
-
-	// Aide internal
-	".aide": true,
-
-	// Node/JavaScript/TypeScript
-	"node_modules": true,
-	"dist":         true,
-	".next":        true,
-	".nuxt":        true,
-	"coverage":     true,
-	".cache":       true,
-
-	// Python
-	"__pycache__":   true,
-	".venv":         true,
-	"venv":          true,
-	".tox":          true,
-	".mypy_cache":   true,
-	".pytest_cache": true,
-	"site-packages": true,
-
-	// Go
-	"vendor": true,
-
-	// Rust
-	"target": true,
-
-	// Java/Kotlin/Gradle
-	"build":   true,
-	".gradle": true,
-	"out":     true,
-
-	// C/C++
-	"cmake-build-debug":   true,
-	"cmake-build-release": true,
-	".cmake":              true,
-	".deps":               true,
-	"Debug":               true,
-	"Release":             true,
-
-	// Ruby
-	".bundle": true,
-
-	// C#
-	"bin": true,
-	"obj": true,
-
-	// Elixir
-	"_build": true,
-	"deps":   true,
-
-	// OCaml
-	"_opam": true,
-
-	// Scala
-	".bloop":  true,
-	".metals": true,
-
-	// Swift
-	".build": true,
-
-	// IDE/Editor
-	".idea":   true,
-	".vscode": true,
-
-	// OS
-	".DS_Store": true,
-}
-
-// DefaultSkipSuffixes contains directory name suffixes to skip during file watching.
-// These require suffix matching because the full directory name is dynamic.
-var DefaultSkipSuffixes = []string{
-	".egg-info", // Python: e.g. "mypackage.egg-info"
-}
-
 type Config struct {
-	Paths         []string
+	Paths []string
+	// ProjectRoot is the absolute path the ignore matcher resolves against.
+	// Defaults to the first entry in Paths, then to the working directory.
+	ProjectRoot   string
 	DebounceDelay time.Duration
-	SkipDirs      []string
 	FileFilter    func(path string) bool
+	// Ignore decides which directories and files are watched. Defaults to
+	// the built-in patterns. Must be the same matcher the indexer and the
+	// analysers use, or incremental and full-scan results diverge.
+	Ignore *aideignore.Matcher
 }
 
 type FileChangeHandler interface {
@@ -115,13 +43,13 @@ func (f FileChangeHandlerFunc) OnChanges(files map[string]fsnotify.Op) {
 }
 
 type Watcher struct {
-	fsnotify  *fsnotify.Watcher
-	config    Config
-	skipSet   map[string]bool // Merged DefaultSkipDirs + Config.SkipDirs
-	stop      chan struct{}
-	stopOnce  sync.Once
-	wg        sync.WaitGroup
-	startTime time.Time
+	fsnotify    *fsnotify.Watcher
+	config      Config
+	projectRoot string
+	stop        chan struct{}
+	stopOnce    sync.Once
+	wg          sync.WaitGroup
+	startTime   time.Time
 
 	mu           sync.Mutex
 	handlers     []FileChangeHandler
@@ -131,21 +59,43 @@ type Watcher struct {
 	dirsWatched  atomic.Int32
 }
 
-// shouldSkipDir returns true if a directory name should be skipped.
-// Checks exact match in skipSet, hidden directories (dot prefix), and suffix patterns.
-func (w *Watcher) shouldSkipDir(name string) bool {
-	if w.skipSet[name] {
-		return true
+// isTransientName matches dotfiles and editor scratch files.
+func isTransientName(name string) bool {
+	return strings.HasPrefix(name, ".") ||
+		strings.HasSuffix(name, "~") ||
+		strings.HasSuffix(name, ".swp") ||
+		strings.HasSuffix(name, ".tmp")
+}
+
+// rel returns path relative to the project root, the form the ignore matcher
+// expects. Paths outside the root are returned unchanged.
+func (w *Watcher) rel(path string) string {
+	r, err := filepath.Rel(w.projectRoot, path)
+	if err != nil {
+		return path
 	}
-	if len(name) > 1 && name[0] == '.' {
-		return true
+	return r
+}
+
+// shouldSkipDir reports whether a directory and its contents go unwatched.
+func (w *Watcher) shouldSkipDir(path string) bool {
+	r := w.rel(path)
+	if r == "." || r == "" {
+		return false
 	}
-	for _, suffix := range DefaultSkipSuffixes {
-		if strings.HasSuffix(name, suffix) {
-			return true
-		}
+	return w.config.Ignore.ShouldIgnoreDir(r)
+}
+
+// shouldWatchFile applies every filter a file must pass to reach a handler.
+// Both the event path and the backfill walk use it.
+func (w *Watcher) shouldWatchFile(path string) bool {
+	if isTransientName(filepath.Base(path)) {
+		return false
 	}
-	return false
+	if w.config.FileFilter != nil && !w.config.FileFilter(path) {
+		return false
+	}
+	return !w.config.Ignore.ShouldIgnoreFile(w.rel(path))
 }
 
 func New(config Config, handlers ...FileChangeHandler) (*Watcher, error) {
@@ -157,22 +107,28 @@ func New(config Config, handlers ...FileChangeHandler) (*Watcher, error) {
 	if config.DebounceDelay == 0 {
 		config.DebounceDelay = DefaultDebounceDelay
 	}
-
-	skipSet := make(map[string]bool)
-	for k, v := range DefaultSkipDirs {
-		skipSet[k] = v
+	if config.Ignore == nil {
+		config.Ignore = aideignore.NewFromDefaults()
 	}
-	for _, d := range config.SkipDirs {
-		skipSet[d] = true
+
+	root := config.ProjectRoot
+	if root == "" && len(config.Paths) > 0 {
+		root = config.Paths[0]
+	}
+	if root == "" {
+		root, _ = os.Getwd()
+	}
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
 	}
 
 	return &Watcher{
-		fsnotify: fsWatcher,
-		config:   config,
-		skipSet:  skipSet,
-		handlers: handlers,
-		stop:     make(chan struct{}),
-		pending:  make(map[string]fsnotify.Op),
+		fsnotify:    fsWatcher,
+		config:      config,
+		projectRoot: root,
+		handlers:    handlers,
+		stop:        make(chan struct{}),
+		pending:     make(map[string]fsnotify.Op),
 	}, nil
 }
 
@@ -195,24 +151,9 @@ func (w *Watcher) Start() error {
 	w.watchPaths = paths
 
 	for _, root := range paths {
-		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return nil
-			}
-			if info.IsDir() {
-				name := info.Name()
-				if w.shouldSkipDir(name) {
-					return filepath.SkipDir
-				}
-				if err := w.fsnotify.Add(path); err == nil {
-					w.dirsWatched.Add(1)
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+		// No backfill: reconciling the existing tree is Indexer.Reconcile's
+		// job, and queueing it here would re-analyse the project on every start.
+		w.addTree(root, false)
 	}
 
 	w.startTime = time.Now()
@@ -221,6 +162,37 @@ func (w *Watcher) Start() error {
 
 	watchLog.Printf("watching %d directories in %v (debounce: %v)", w.dirsWatched.Load(), paths, w.config.DebounceDelay)
 	return nil
+}
+
+// addTree watches dir and every non-ignored directory beneath it, recursing
+// because `mkdir -p a/b/c` reports only "a".
+//
+// When backfill is true it also queues the files already present. Nothing
+// else ever sees them: a directory has no watch until it is registered, so
+// anything written before that — a file created right after mkdir, or the
+// contents of a directory renamed into place — emits no event at all.
+func (w *Watcher) addTree(dir string, backfill bool) {
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			// The caller vetted dir; skipping it here would make an
+			// explicitly configured watch path unwatchable.
+			if path != dir && w.shouldSkipDir(path) {
+				return filepath.SkipDir
+			}
+			if err := w.fsnotify.Add(path); err == nil {
+				w.dirsWatched.Add(1)
+			}
+			return nil
+		}
+		if !backfill || !w.shouldWatchFile(path) {
+			return nil
+		}
+		w.queueChange(path, fsnotify.Create)
+		return nil
+	})
 }
 
 func (w *Watcher) Stop() error {
@@ -275,24 +247,15 @@ func (w *Watcher) processEvents() {
 
 			if event.Op&fsnotify.Create != 0 {
 				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
-					name := filepath.Base(event.Name)
-					if !w.shouldSkipDir(name) {
-						if err := w.fsnotify.Add(event.Name); err == nil {
-							w.dirsWatched.Add(1)
-							watchLog.Printf("watching new directory: %s", event.Name)
-						}
+					if !w.shouldSkipDir(event.Name) {
+						watchLog.Printf("watching new directory: %s", event.Name)
+						w.addTree(event.Name, true)
 					}
 					continue
 				}
 			}
 
-			if w.config.FileFilter != nil && !w.config.FileFilter(event.Name) {
-				continue
-			}
-
-			name := filepath.Base(event.Name)
-			if strings.HasPrefix(name, ".") || strings.HasSuffix(name, "~") ||
-				strings.HasSuffix(name, ".swp") || strings.HasSuffix(name, ".tmp") {
+			if !w.shouldWatchFile(event.Name) {
 				continue
 			}
 
@@ -311,7 +274,8 @@ func (w *Watcher) processEvents() {
 
 func (w *Watcher) queueChange(path string, op fsnotify.Op) {
 	w.mu.Lock()
-	w.pending[path] = op
+	// Union, not assignment: a write then a delete in one window is a delete.
+	w.pending[path] |= op
 	w.debounceOnce.Do(func() {
 		w.wg.Add(1)
 		go func() {
@@ -341,6 +305,8 @@ func (w *Watcher) flushPending() {
 		return
 	}
 
+	normaliseRemovals(pending)
+
 	watchLog.Printf("processing %d file changes", len(pending))
 
 	for _, h := range handlers {
@@ -352,6 +318,21 @@ func (w *Watcher) flushPending() {
 			}()
 			h.OnChanges(pending)
 		}()
+	}
+}
+
+// normaliseRemovals marks any renamed-or-removed path that is gone from disk
+// as a removal. fsnotify reports a rename as RENAME on the source path, and
+// backends disagree on which op a delete produces; without this a handler
+// re-indexes a file that no longer exists and keeps its stale rows forever.
+func normaliseRemovals(pending map[string]fsnotify.Op) {
+	for path, op := range pending {
+		if op&(fsnotify.Rename|fsnotify.Remove) == 0 {
+			continue
+		}
+		if _, err := os.Lstat(path); os.IsNotExist(err) {
+			pending[path] = op | fsnotify.Remove
+		}
 	}
 }
 

--- a/aide/pkg/watcher/watcher_test.go
+++ b/aide/pkg/watcher/watcher_test.go
@@ -1,0 +1,333 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/jmylchreest/aide/aide/pkg/aideignore"
+)
+
+const (
+	testDebounce = 150 * time.Millisecond
+	// settle covers inotify, the debounce timer and the handler, with enough
+	// headroom that a loaded CI box doesn't flake.
+	settle = 800 * time.Millisecond
+)
+
+type collector struct {
+	mu    sync.Mutex
+	seen  map[string]fsnotify.Op
+	calls int
+}
+
+func newCollector() *collector {
+	return &collector{seen: map[string]fsnotify.Op{}}
+}
+
+func (c *collector) OnChanges(files map[string]fsnotify.Op) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	for k, v := range files {
+		c.seen[k] |= v
+	}
+}
+
+func (c *collector) op(path string) (fsnotify.Op, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	op, ok := c.seen[path]
+	return op, ok
+}
+
+func (c *collector) has(path string) bool {
+	_, ok := c.op(path)
+	return ok
+}
+
+func (c *collector) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.seen)
+}
+
+// testRoot returns a temp directory with symlinks resolved: on macOS /tmp is a
+// symlink, so fsnotify would report paths the test can't match.
+func testRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func startWatcher(t *testing.T, root string, ignore *aideignore.Matcher) *collector {
+	t.Helper()
+	c := newCollector()
+	w, err := New(Config{
+		Paths:         []string{root},
+		ProjectRoot:   root,
+		DebounceDelay: testDebounce,
+		FileFilter:    func(p string) bool { return strings.HasSuffix(p, ".go") },
+		Ignore:        ignore,
+	}, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = w.Stop() })
+	time.Sleep(100 * time.Millisecond) // let the watches register
+	return c
+}
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Guards the rest of the suite against a watcher that reports nothing at all.
+func TestWatcherReportsWriteInWatchedDir(t *testing.T) {
+	root := testRoot(t)
+	c := startWatcher(t, root, nil)
+
+	path := filepath.Join(root, "a.go")
+	writeFile(t, path)
+
+	time.Sleep(settle)
+	if !c.has(path) {
+		t.Fatalf("write in watched directory not reported: %s", path)
+	}
+}
+
+// A file written immediately after mkdir emits no event — the directory has no
+// watch yet — so only the backfill walk sees it.
+func TestWatcherBackfillsNewDirectory(t *testing.T) {
+	root := testRoot(t)
+	c := startWatcher(t, root, nil)
+
+	dir := filepath.Join(root, "pkg")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "new.go")
+	writeFile(t, path)
+
+	time.Sleep(settle)
+	if !c.has(path) {
+		t.Fatalf("file in newly created directory not reported: %s", path)
+	}
+}
+
+// `mkdir -p a/b/c` reports only "a"; without recursing, b and c never get
+// watched and nothing inside them is seen again.
+func TestWatcherWatchesNestedNewDirectories(t *testing.T) {
+	root := testRoot(t)
+	c := startWatcher(t, root, nil)
+
+	dir := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "deep.go")
+	writeFile(t, path)
+
+	time.Sleep(settle)
+	if !c.has(path) {
+		t.Fatalf("file in nested new directory not reported: %s", path)
+	}
+
+	// A later write proves the leaf got a watch, rather than the file merely
+	// being caught by the backfill.
+	c.mu.Lock()
+	delete(c.seen, path)
+	c.mu.Unlock()
+
+	writeFile(t, path)
+	time.Sleep(settle)
+	if !c.has(path) {
+		t.Fatalf("nested directory did not get an inotify watch: %s", path)
+	}
+}
+
+// A directory renamed into place arrives with its contents already inside, so
+// no per-file event is emitted. This is what a branch checkout looks like.
+func TestWatcherBackfillsDirectoryRenamedIntoPlace(t *testing.T) {
+	root := testRoot(t)
+	staging := testRoot(t)
+	c := startWatcher(t, root, nil)
+
+	src := filepath.Join(staging, "mod")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(src, "x.go"))
+
+	dst := filepath.Join(root, "mod")
+	if err := os.Rename(src, dst); err != nil {
+		t.Skipf("cross-device rename unavailable: %v", err)
+	}
+
+	time.Sleep(settle)
+	if !c.has(filepath.Join(dst, "x.go")) {
+		t.Fatalf("contents of directory renamed into place not reported")
+	}
+}
+
+// fsnotify reports a rename as RENAME on the source path; handlers must see a
+// removal or they keep the vanished file's stale rows forever.
+func TestWatcherNormalisesRenameToRemove(t *testing.T) {
+	root := testRoot(t)
+	old := filepath.Join(root, "old.go")
+	writeFile(t, old)
+
+	c := startWatcher(t, root, nil)
+
+	renamed := filepath.Join(root, "new.go")
+	if err := os.Rename(old, renamed); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(settle)
+
+	op, ok := c.op(old)
+	if !ok {
+		t.Fatalf("rename source not reported: %s", old)
+	}
+	if !IsRemove(op) {
+		t.Errorf("rename source op = %v, want a removal", op)
+	}
+
+	op, ok = c.op(renamed)
+	if !ok {
+		t.Fatalf("rename destination not reported: %s", renamed)
+	}
+	if IsRemove(op) {
+		t.Errorf("rename destination op = %v, want a live file", op)
+	}
+}
+
+// A delete arriving after a write in the same window is still a delete.
+func TestWatcherCoalescesWriteThenRemoveAsRemove(t *testing.T) {
+	root := testRoot(t)
+	path := filepath.Join(root, "doomed.go")
+	writeFile(t, path)
+
+	c := startWatcher(t, root, nil)
+
+	writeFile(t, path)
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(settle)
+
+	op, ok := c.op(path)
+	if !ok {
+		t.Fatalf("write-then-remove not reported: %s", path)
+	}
+	if !IsRemove(op) {
+		t.Errorf("op = %v, want a removal", op)
+	}
+}
+
+// Start must not replay the existing tree — that is Indexer.Reconcile's job.
+func TestWatcherStartDoesNotBackfillExistingTree(t *testing.T) {
+	root := testRoot(t)
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(root, "a.go"))
+	writeFile(t, filepath.Join(root, "sub", "b.go"))
+
+	c := startWatcher(t, root, nil)
+	time.Sleep(settle)
+
+	if n := c.count(); n != 0 {
+		t.Errorf("Start reported %d pre-existing files, want 0", n)
+	}
+}
+
+// The ignore matcher applies to directories that appear after startup too.
+func TestWatcherHonoursIgnoreMatcherForNewDirectory(t *testing.T) {
+	root := testRoot(t)
+	c := startWatcher(t, root, nil)
+
+	dir := filepath.Join(root, "node_modules", "pkg")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "ignored.go"))
+
+	time.Sleep(settle)
+	if n := c.count(); n != 0 {
+		t.Errorf("reported %d files under an ignored directory, want 0", n)
+	}
+}
+
+// A .aideignore negation re-includes a directory the built-in defaults exclude.
+// The watcher could not honour this while it carried its own skip list.
+func TestWatcherHonoursIgnoreNegation(t *testing.T) {
+	root := testRoot(t)
+	if err := os.WriteFile(filepath.Join(root, ".aideignore"), []byte("!dist/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ignore, err := aideignore.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ignore.ShouldIgnoreDir("dist") {
+		t.Skip("aideignore does not re-include dist/; negation semantics differ")
+	}
+
+	c := startWatcher(t, root, ignore)
+
+	dir := filepath.Join(root, "dist")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "kept.go")
+	writeFile(t, path)
+
+	time.Sleep(settle)
+	if !c.has(path) {
+		t.Errorf("re-included directory not watched: %s", path)
+	}
+}
+
+// Rejected and scratch files reach handlers from neither path.
+func TestWatcherFiltersNonMatchingAndTransientFiles(t *testing.T) {
+	root := testRoot(t)
+	c := startWatcher(t, root, nil)
+
+	dir := filepath.Join(root, "pkg")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "keep.go"))
+	writeFile(t, filepath.Join(dir, "skip.md"))
+	writeFile(t, filepath.Join(dir, ".hidden.go"))
+	writeFile(t, filepath.Join(dir, "scratch.go~"))
+	writeFile(t, filepath.Join(dir, "scratch.go.swp"))
+
+	time.Sleep(settle)
+
+	if !c.has(filepath.Join(dir, "keep.go")) {
+		t.Error("matching file not reported")
+	}
+	for _, name := range []string{"skip.md", ".hidden.go", "scratch.go~", "scratch.go.swp"} {
+		if c.has(filepath.Join(dir, name)) {
+			t.Errorf("filtered file reported: %s", name)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

A user reported that auto-indexing on file change doesn't always produce new findings, but a full reindex does.

Root cause: **files arriving in a directory created after the watcher started were never seen at all.** A directory has no inotify watch until it is created and registered, so anything written before that registration emits no event. Measured on Linux with a 150ms debounce:

| scenario | files missed |
|---|---|
| `mkdir d` then write `d/new.go` | 9 / 10 |
| `mkdir -p a/b/c` then write `a/b/c/deep.go` | 10 / 10 — only `a` was ever watched |
| directory with contents renamed into place (branch checkout) | 1 / 1 |
| write into an already-watched dir (control) | 0 / 1 ✓ |

Nothing healed it afterwards: `Indexer.Reconcile` only iterated `ListAllFileInfo()`, so it could not see a file that had never been indexed, and it never told the findings runner about anything it did fix.

## Changes

**`pkg/watcher`**
- `addTree` walks a newly created directory, watches every non-ignored descendant, and queues the files already inside. `Start` uses it without the backfill — reconciling the existing tree stays `Reconcile`'s job.
- Normalise a renamed-or-removed path that is gone from disk to a removal. fsnotify reports a rename as `RENAME` on the source path, so `IsRemove` was false and handlers re-parsed vanished files, keeping their stale symbols and findings indefinitely.
- Union pending ops instead of overwriting, so a write followed by a delete inside one debounce window still reaches handlers as a delete.
- Drop `DefaultSkipDirs` / `DefaultSkipSuffixes` / `Config.SkipDirs` in favour of the `aideignore` matcher the indexer and analysers already use. Two skip lists is what let incremental and full-scan results disagree, and the hardcoded one could not honour a `!pattern` re-include.

**`cmd/aide` — code index**
- `Reconcile` always walks the working tree, skipping entries it already handled, so a file the watcher missed is discovered. The empty-store bootstrap falls out of this rather than being a special case.
- New `ReconcileResult.Touched`; `startCodeReconciler` hands those paths to the findings runner, so the index and the findings heal together instead of the index healing alone.

**`pkg/aideignore`**
- Add the dot-directory build and cache output the watcher used to skip via its blanket dot rule — `.turbo`, `.nx`, `.svelte-kit`, `.astro`, `.vercel`, `.docusaurus`, `.terraform`, `.direnv`, `.ruff_cache`, `.dart_tool`, `.stack-work` and friends. Without this, dropping that rule would cost inotify watches on them. `.yarn` is scoped to `cache/` and `unplugged/` because `releases/` and `patches/` are committed source. All of these remain re-includable with `!pattern` in `.aideignore`.

## Behaviour change

The watcher no longer blanket-skips every dot-directory. That's the point — `aide code index` and `aide findings scan` already walk `.github/`, `.claude/` and the rest, so the watcher now matches them, and the additions above cover the dot-dirs that are genuinely build output.

## Tests

First tests for `pkg/watcher` (10, no skips): new-directory backfill, `mkdir -p` including a follow-up write proving the leaf got a real watch, directory renamed into place, rename→remove normalisation, write-then-remove coalescing, `Start` not backfilling, ignore enforcement on new directories, `.aideignore` negation re-including `dist/`, and filter/scratch-file rejection. Plus two `Reconcile` tests for discovery and `Touched`.

`go build`, `go vet` and `go test ./...` are green.

## Not in this PR

`todos` and `deadcode` still never run incrementally — `OnChanges` only dispatches complexity/secrets/security and coupling/clones, while `aide findings scan` runs all seven. Follow-up PR.

https://claude.ai/code/session_01DaZEV8Lf9j5xrRXuhV5mi1
