### PR TITLE
feat(findings): run todos and deadcode on file change

### DIFF
--- a/aide/cmd/aide/cmd_mcp.go
+++ b/aide/cmd/aide/cmd_mcp.go
@@ -530,6 +530,12 @@ func (s *MCPServer) startCodeWatcher(dbPath string, cfg *mcpConfig) {
 				f, _, err := clone.DetectClones(cloneCfg)
 				return f, err
 			})
+			if fcfg.DeadCode.Watch == nil || *fcfg.DeadCode.Watch {
+				findingsRunner.SetDeadCodeRunner(func(ctx context.Context) ([]*findings.Finding, error) {
+					return runWatcherDeadCode(s.getCodeStore(), projectRoot)
+				})
+			}
+
 			handlers = append(handlers, findingsRunner)
 		} else {
 			mcpLog.Printf("WARNING: findings store not available, findings analysis disabled in watcher")
@@ -701,6 +707,44 @@ func rescanForGrammar(name string, indexer *Indexer, runner *findings.Runner, ro
 	if runner != nil && len(findingsFiles) > 0 {
 		runner.OnChanges(findingsFiles)
 	}
+}
+
+// runWatcherDeadCode runs the dead-code analyser against the live code index.
+// An empty index is not an error here — the watcher runs before anything has
+// been indexed on a fresh project, and reporting "no dead code" is the honest
+// answer until there are symbols to check.
+func runWatcherDeadCode(cs store.CodeIndexStore, projectRoot string) ([]*findings.Finding, error) {
+	if cs == nil {
+		return nil, nil
+	}
+	stats, err := cs.Stats()
+	if err != nil {
+		return nil, fmt.Errorf("read code stats: %w", err)
+	}
+	if stats.Symbols == 0 {
+		return nil, nil
+	}
+
+	registry := grammar.DefaultPackRegistry()
+	ff, _, err := findings.AnalyzeDeadCode(findings.DeadCodeConfig{
+		GetAllSymbols: func() ([]*code.Symbol, error) {
+			return cs.ListAllSymbols(-1)
+		},
+		GetRefCount: func(name string) (int, error) {
+			refs, err := cs.SearchReferences(code.ReferenceSearchOptions{
+				SymbolName: name,
+				Limit:      1,
+			})
+			if err != nil {
+				return 0, err
+			}
+			return len(refs), nil
+		},
+		ProjectRoot:        projectRoot,
+		PackProvider:       registry.Get,
+		ConsumerExtensions: registry.ConsumerExtensions(),
+	})
+	return ff, err
 }
 
 // stopCodeWatcher gracefully stops the file watcher if running.

--- a/aide/cmd/aide/helpers.go
+++ b/aide/cmd/aide/helpers.go
@@ -199,6 +199,13 @@ type findingsConfig struct {
 		MinSimilarity float64 `json:"minSimilarity"`
 		MinSeverity   string  `json:"minSeverity"`
 	} `json:"clones"`
+	DeadCode struct {
+		// Watch enables the dead-code analyser in the file watcher. It is the
+		// most expensive analyser — a whole-index pass plus text verification —
+		// so it can be disabled without losing it from `aide findings scan`.
+		// Defaults to true.
+		Watch *bool `json:"watch,omitempty"`
+	} `json:"deadcode"`
 }
 
 // aideJSON is the top-level structure of .aide/config/aide.json.

--- a/aide/pkg/findings/runner.go
+++ b/aide/pkg/findings/runner.go
@@ -84,11 +84,17 @@ type ClonesRunnerConfig struct {
 
 type ClonesRunner func(ctx context.Context, paths []string, cfg ClonesRunnerConfig) ([]*Finding, error)
 
+// DeadCodeRunner runs the dead-code analyser. Like ClonesRunner it is injected
+// rather than called directly: the analyser needs the code index, which this
+// package cannot import without a cycle.
+type DeadCodeRunner func(ctx context.Context) ([]*Finding, error)
+
 type Runner struct {
-	store        ReplaceFindingsStore
-	config       AnalyzerConfig
-	clonesRunner ClonesRunner
-	loader       grammar.Loader
+	store          ReplaceFindingsStore
+	config         AnalyzerConfig
+	clonesRunner   ClonesRunner
+	deadCodeRunner DeadCodeRunner
+	loader         grammar.Loader
 
 	mu            sync.Mutex
 	runs          map[RunKey]*activeRun
@@ -135,6 +141,40 @@ func (r *Runner) SetClonesRunner(fn ClonesRunner) {
 	r.clonesRunner = fn
 }
 
+func (r *Runner) SetDeadCodeRunner(fn DeadCodeRunner) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deadCodeRunner = fn
+}
+
+func (r *Runner) clones() ClonesRunner {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.clonesRunner
+}
+
+func (r *Runner) deadCode() DeadCodeRunner {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.deadCodeRunner
+}
+
+// perFileAnalyzers lists the analysers that run against one file's contents.
+func perFileAnalyzers() []string {
+	return []string{AnalyzerComplexity, AnalyzerSecrets, AnalyzerSecurity, AnalyzerTodos}
+}
+
+// projectAnalyzers lists the whole-project analysers to run. Dead code joins
+// them only once a runner is wired, since without the code index it has
+// nothing to analyse.
+func (r *Runner) projectAnalyzers() []string {
+	analyzers := []string{AnalyzerCoupling, AnalyzerClones}
+	if r.deadCode() != nil {
+		analyzers = append(analyzers, AnalyzerDeadCode)
+	}
+	return analyzers
+}
+
 // ignore returns the configured aideignore matcher, falling back to built-in
 // defaults. The default matcher is cached on first use to avoid repeated
 // allocation.
@@ -151,8 +191,8 @@ func (r *Runner) ignore() *aideignore.Matcher {
 }
 
 func (r *Runner) OnChanges(files map[string]fsnotify.Op) {
-	perFileAnalyzers := []string{AnalyzerComplexity, AnalyzerSecrets, AnalyzerSecurity}
-	projectAnalyzers := []string{AnalyzerCoupling, AnalyzerClones}
+	perFileAnalyzers := perFileAnalyzers()
+	projectAnalyzers := r.projectAnalyzers()
 
 	ignore := r.ignore()
 
@@ -318,6 +358,8 @@ func (r *Runner) runPerFileAnalyzer(ctx context.Context, analyzer string, file s
 		return r.analyzeFileSecrets(ctx, relPath, content)
 	case AnalyzerSecurity:
 		return r.analyzeFileSecurity(ctx, relPath, content)
+	case AnalyzerTodos:
+		return analyzeFileTodos(relPath, content), nil
 	default:
 		return nil, fmt.Errorf("unknown analyzer: %s", analyzer)
 	}
@@ -353,8 +395,16 @@ func (r *Runner) runProjectAnalyzer(ctx context.Context, analyzer string) ([]*Fi
 		findings, _, err := AnalyzeCoupling(cfg)
 		return findings, err
 
+	case AnalyzerDeadCode:
+		run := r.deadCode()
+		if run == nil {
+			return nil, fmt.Errorf("deadcode runner not configured")
+		}
+		return run(ctx)
+
 	case AnalyzerClones:
-		if r.clonesRunner == nil {
+		clones := r.clones()
+		if clones == nil {
 			return nil, fmt.Errorf("clones runner not configured")
 		}
 		// Defaults mirror clone.DefaultWindowSize / clone.DefaultMinCloneLines.
@@ -368,7 +418,7 @@ func (r *Runner) runProjectAnalyzer(ctx context.Context, analyzer string) ([]*Fi
 		if minLines <= 0 {
 			minLines = DefaultCloneMinLines
 		}
-		return r.clonesRunner(ctx, paths, ClonesRunnerConfig{
+		return clones(ctx, paths, ClonesRunnerConfig{
 			WindowSize:    windowSize,
 			MinLines:      minLines,
 			MinMatchCount: r.config.CloneMinMatchCount,
@@ -484,10 +534,9 @@ func (r *Runner) Stop() {
 }
 
 // RunAll schedules analysis of all supported files in the configured paths.
-// Per-file analysers (complexity, secrets) are launched per file; project-wide
-// analysers (coupling, clones) are launched once. All analysers run
-// asynchronously via runAnalyzer — use WaitAll() to block until completion,
-// or Stop() to cancel and drain.
+// Per-file analysers are launched per file, project-wide analysers once. All
+// run asynchronously via runAnalyzer — use WaitAll() to block until
+// completion, or Stop() to cancel and drain.
 func (r *Runner) RunAll(ctx context.Context) error {
 	paths := r.config.Paths
 	if len(paths) == 0 {
@@ -518,7 +567,7 @@ func (r *Runner) RunAll(ctx context.Context) error {
 			}
 
 			scopePath := toRelPath(r.config.ProjectRoot, path)
-			for _, analyzer := range []string{AnalyzerComplexity, AnalyzerSecrets, AnalyzerSecurity} {
+			for _, analyzer := range perFileAnalyzers() {
 				key := RunKey{Analyzer: analyzer, Scope: scopePath}
 				r.runAnalyzer(key, func(ctx context.Context) ([]*Finding, error) {
 					return r.runPerFileAnalyzer(ctx, analyzer, path)
@@ -531,7 +580,7 @@ func (r *Runner) RunAll(ctx context.Context) error {
 		}
 	}
 
-	for _, analyzer := range []string{AnalyzerCoupling, AnalyzerClones} {
+	for _, analyzer := range r.projectAnalyzers() {
 		key := RunKey{Analyzer: analyzer, Scope: ScopeProject}
 		r.runAnalyzer(key, func(ctx context.Context) ([]*Finding, error) {
 			return r.runProjectAnalyzer(ctx, analyzer)

--- a/aide/pkg/findings/runner_test.go
+++ b/aide/pkg/findings/runner_test.go
@@ -1,7 +1,11 @@
 package findings
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/fsnotify/fsnotify"
@@ -73,8 +77,8 @@ func TestOnChanges_RemoveDeletesFindings(t *testing.T) {
 	calls := store.replacedAnalyzerAndFile
 	store.mu.Unlock()
 
-	if len(calls) != 3 {
-		t.Fatalf("expected 3 ReplaceFindingsForAnalyzerAndFile calls (complexity + secrets + security), got %d", len(calls))
+	if len(calls) != len(perFileAnalyzers()) {
+		t.Fatalf("expected %d ReplaceFindingsForAnalyzerAndFile calls, got %d", len(perFileAnalyzers()), len(calls))
 	}
 
 	analyzers := map[string]bool{}
@@ -96,6 +100,9 @@ func TestOnChanges_RemoveDeletesFindings(t *testing.T) {
 	}
 	if !analyzers[AnalyzerSecurity] {
 		t.Error("expected security analyzer findings to be cleared")
+	}
+	if !analyzers[AnalyzerTodos] {
+		t.Error("expected todos analyzer findings to be cleared")
 	}
 }
 
@@ -216,4 +223,119 @@ func TestOnChanges_UnsupportedFileIgnored(t *testing.T) {
 	if len(calls) != 0 {
 		t.Errorf("expected 0 calls for unsupported file, got %d", len(calls))
 	}
+}
+
+// Todos runs per file on change. Before this it ran only in `aide findings
+// scan`, so a TODO added between full scans never surfaced.
+func TestOnChanges_RunsTodosAnalyzer(t *testing.T) {
+	store := &mockReplaceFindingsStore{}
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "todo.go")
+	src := "package demo\n\n// TODO: tidy this up\n// BUG: panics on empty slice\nfunc demo() {}\n"
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := NewRunner(store, AnalyzerConfig{
+		ProjectRoot: tmp,
+		Ignore:      aideignore.NewEmpty(),
+	}, nil)
+	defer runner.Stop()
+
+	runner.OnChanges(map[string]fsnotify.Op{path: fsnotify.Write})
+	runner.WaitAll()
+
+	store.mu.Lock()
+	calls := store.replacedAnalyzerAndFile
+	store.mu.Unlock()
+
+	var todos []*Finding
+	found := false
+	for _, c := range calls {
+		if c.Analyzer == AnalyzerTodos {
+			found = true
+			todos = c.Findings
+		}
+	}
+	if !found {
+		t.Fatalf("todos analyzer did not run on a changed file (analyzers: %v)", calls)
+	}
+	if len(todos) != 2 {
+		t.Fatalf("expected 2 todo findings, got %d", len(todos))
+	}
+	for _, f := range todos {
+		if f.FilePath != "todo.go" {
+			t.Errorf("finding path = %q, want project-relative todo.go", f.FilePath)
+		}
+	}
+}
+
+// Dead code needs the code index, so it is only scheduled once a runner is
+// wired. Without the guard every change would schedule an analyzer that can
+// only fail.
+func TestProjectAnalyzers_DeadCodeRequiresRunner(t *testing.T) {
+	runner := NewRunner(&mockReplaceFindingsStore{}, AnalyzerConfig{}, nil)
+	defer runner.Stop()
+
+	for _, a := range runner.projectAnalyzers() {
+		if a == AnalyzerDeadCode {
+			t.Fatal("deadcode scheduled without a runner")
+		}
+	}
+
+	runner.SetDeadCodeRunner(func(context.Context) ([]*Finding, error) { return nil, nil })
+
+	var found bool
+	for _, a := range runner.projectAnalyzers() {
+		if a == AnalyzerDeadCode {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("deadcode not scheduled after wiring a runner")
+	}
+}
+
+func TestOnChanges_RunsDeadCodeRunner(t *testing.T) {
+	store := &mockReplaceFindingsStore{}
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "a.go")
+	if err := os.WriteFile(path, []byte("package demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := NewRunner(store, AnalyzerConfig{
+		ProjectRoot: tmp,
+		Ignore:      aideignore.NewEmpty(),
+	}, nil)
+	defer runner.Stop()
+
+	var called atomic.Bool
+	runner.SetDeadCodeRunner(func(context.Context) ([]*Finding, error) {
+		called.Store(true)
+		return []*Finding{{Analyzer: AnalyzerDeadCode, FilePath: "a.go", Title: "unused"}}, nil
+	})
+
+	runner.OnChanges(map[string]fsnotify.Op{path: fsnotify.Write})
+	runner.WaitAll()
+
+	if !called.Load() {
+		t.Fatal("deadcode runner was not invoked on a file change")
+	}
+
+	store.mu.Lock()
+	calls := store.replacedAnalyzer
+	store.mu.Unlock()
+
+	for _, c := range calls {
+		if c.Analyzer == AnalyzerDeadCode {
+			if len(c.Findings) != 1 {
+				t.Errorf("expected the runner's finding to be stored, got %d", len(c.Findings))
+			}
+			return
+		}
+	}
+	t.Error("deadcode findings were not stored project-wide")
 }

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -118,6 +118,9 @@ Project-level settings can be stored in `.aide/config/aide.json`:
     "clones": {
       "windowSize": 50,
       "minLines": 6
+    },
+    "deadcode": {
+      "watch": true
     }
   }
 }
@@ -130,6 +133,7 @@ Project-level settings can be stored in `.aide/config/aide.json`:
 | `findings.coupling.fanIn`       | 20      | Maximum incoming imports before flagging     |
 | `findings.clones.windowSize`    | 50      | Sliding window size in tokens for detection  |
 | `findings.clones.minLines`      | 6       | Minimum clone size in lines to report        |
+| `findings.deadcode.watch`       | true    | Run the dead-code analyser on file change. It is the most expensive analyser — a whole-index pass plus text verification — so set `false` to leave it to `aide findings scan` |
 
 | `code.respect_gitignore`        | true    | Apply the repo's `.gitignore` rules to analysis — see [File Exclusions](#file-exclusions) |
 | `cleanup.enabled`               | true    | Master switch for retention pruning (daemon loop + session-init sweep) |


### PR DESCRIPTION
Follow-up to #60, closing the last gap between incremental analysis and a full scan.

## Problem

`Runner.OnChanges` dispatched only `complexity`, `secrets`, `security` (per-file) and `coupling`, `clones` (project-wide), while `aide findings scan` runs all seven analysers. `todos` and `deadcode` could therefore only ever come from a full scan — a TODO added between scans, or a symbol whose last caller was just deleted, stayed invisible until someone ran one by hand.

## Changes

**todos** joins the per-file analysers. `analyzeFileTodos` was already pure and per-file, so this is a dispatch case plus the list entry.

**deadcode** joins the project analysers behind an injected `DeadCodeRunner`, mirroring the existing `ClonesRunner`: the analyser needs the code index, which `pkg/findings` can't import without a cycle. It's scheduled only once that runner is wired, so a `Runner` without one never queues an analyser that can only fail.

Ordering is already correct — the watcher's handler list is `[codeHandler, findingsRunner]` and `flushPending` invokes handlers in order, so the index is current before dead code reads it.

An empty code index is not an error for the watcher's pass: the watcher runs before anything is indexed on a fresh project, and "no dead code" is the honest answer until there are symbols to check. (The CLI and gRPC paths keep their existing `code index is empty` error.)

**Escape hatch**: `findings.deadcode.watch` (default `true`). Dead code is the most expensive analyser — a whole-index pass plus text-grep verification — and it now runs on every debounce flush. Setting it `false` leaves it in `aide findings scan`. Documented in `docs/getting-started/configuration.md`.

**Drive-by**: `clonesRunner` was read without the mutex that `SetClonesRunner` takes. Both runners now go through locked accessors.

## Tests

- `TestOnChanges_RunsTodosAnalyzer` — a changed file with `TODO:` and `BUG:` yields two todos findings at the project-relative path.
- `TestProjectAnalyzers_DeadCodeRequiresRunner` — absent without a wired runner, present with one.
- `TestOnChanges_RunsDeadCodeRunner` — the runner is invoked on a change and its findings are stored project-wide.
- `TestOnChanges_RemoveDeletesFindings` now asserts against `perFileAnalyzers()` rather than a hardcoded 3, and checks todos findings are cleared on delete.

`go build`, `go vet` and `go test ./...` are green.

https://claude.ai/code/session_01DaZEV8Lf9j5xrRXuhV5mi1
