### PR TITLE
chore: add legal pages and plugin listing metadata

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,9 @@
     "name": "John Mylchreest"
   },
   "homepage": "https://github.com/jmylchreest/aide",
+  "websiteURL": "https://jmylchreest.github.io/aide/",
+  "privacyPolicyURL": "https://jmylchreest.github.io/aide/legal/privacy",
+  "termsOfServiceURL": "https://jmylchreest.github.io/aide/legal/terms",
   "repository": "https://github.com/jmylchreest/aide",
   "keywords": [
     "memory",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -6,6 +6,9 @@
     "name": "John Mylchreest"
   },
   "homepage": "https://github.com/jmylchreest/aide",
+  "websiteURL": "https://jmylchreest.github.io/aide/",
+  "privacyPolicyURL": "https://jmylchreest.github.io/aide/legal/privacy",
+  "termsOfServiceURL": "https://jmylchreest.github.io/aide/legal/terms",
   "repository": "https://github.com/jmylchreest/aide",
   "keywords": [
     "memory",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AIDE - AI Development Environment
 
+[![HOL Trust Score](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Djmylchreest%252Faide%26metric%3Dtrust%26label%3Dhol%2520trust)](https://hol.org/registry/plugins/jmylchreest%2Faide)
+[![HOL Security Score](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Djmylchreest%252Faide%26metric%3Dsecurity%26label%3Dhol%2520security)](https://hol.org/registry/plugins/jmylchreest%2Faide)
+
 Persistent memory, code intelligence, and multi-agent orchestration for AI coding assistants. Works with **Claude Code**, **OpenCode**, and **Codex CLI**.
 
 **Prerequisite:** [Bun](https://bun.sh/) — the only runtime dependency. The Go binary downloads automatically.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -144,6 +144,13 @@ const config: Config = {
             { label: "OpenCode", href: "https://opencode.ai" },
           ],
         },
+        {
+          title: "Legal",
+          items: [
+            { label: "Privacy Policy", to: "/legal/privacy" },
+            { label: "Terms of Service", to: "/legal/terms" },
+          ],
+        },
       ],
       copyright: `Copyright ${new Date().getFullYear()} AIDE. Built with Docusaurus.`,
     },

--- a/docs/src/pages/legal/privacy.md
+++ b/docs/src/pages/legal/privacy.md
@@ -1,0 +1,71 @@
+---
+title: Privacy Policy
+description: "How AIDE handles your data — no telemetry, all state local to your machine."
+---
+
+# Privacy Policy
+
+_Last updated: 2026-09-03_
+
+AIDE is a locally-executed developer tool. It has no backend service, no user
+accounts, and no analytics. This policy describes what AIDE does with data on
+your machine and the only network calls it makes.
+
+## What AIDE collects
+
+**Nothing is collected by the author.** There is no telemetry, usage reporting,
+crash reporting, or analytics of any kind. No data is transmitted to
+`jmylchreest` or to any service operated on AIDE's behalf.
+
+## What AIDE stores, and where
+
+AIDE writes all of its state to your own filesystem:
+
+- **Project state** — memories, decisions, tasks, findings, code index, and
+  session events are stored in the `.aide/` directory inside each project.
+- **User state** — configuration and downloaded binaries and grammars are stored
+  under your user config and cache directories.
+
+This data stays on your machine. It is yours to inspect, edit, or delete at any
+time — removing the `.aide/` directory removes all project state. Because
+`.aide/` may contain excerpts of your source code and session activity, treat it
+with the same care as the repository itself and keep it out of version control
+unless you intend to share it.
+
+## Network requests AIDE makes
+
+AIDE makes no network request other than these:
+
+| Destination | Purpose | Data sent |
+| --- | --- | --- |
+| `api.github.com`, `github.com` | Check for and download AIDE release binaries and Tree-sitter grammars | Standard HTTP request metadata only |
+| `api.anthropic.com/api/oauth/usage` | Read **your own** plan usage to display it in the status dashboard | Your existing Claude credential, supplied by your assistant |
+
+The Anthropic usage request is a read of your own account, authenticated with
+the credential your AI assistant already holds. AIDE does not create, store, or
+transmit credentials of its own.
+
+## Your AI assistant is separate
+
+AIDE runs as a plugin inside Claude Code, OpenCode, or Codex. Those tools send
+your prompts and code to their respective model providers under their own terms.
+AIDE does not control or intercept that, and this policy does not cover it —
+see the privacy policy of the assistant and model provider you use.
+
+## This documentation site
+
+These docs are published with GitHub Pages, which is subject to
+[GitHub's Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement).
+The site itself sets no tracking cookies and embeds no analytics.
+
+## Changes
+
+Changes to this policy are made in the
+[AIDE repository](https://github.com/jmylchreest/aide) and carry the commit
+history as their record.
+
+## Contact
+
+Questions or concerns: open an issue at
+[github.com/jmylchreest/aide/issues](https://github.com/jmylchreest/aide/issues).
+For security reports, follow [SECURITY.md](https://github.com/jmylchreest/aide/blob/main/SECURITY.md).

--- a/docs/src/pages/legal/terms.md
+++ b/docs/src/pages/legal/terms.md
@@ -1,0 +1,67 @@
+---
+title: Terms of Service
+description: "The MIT-licensed terms on which AIDE is provided, and your responsibilities when running agents."
+---
+
+# Terms of Service
+
+_Last updated: 2026-09-03_
+
+AIDE is free, open-source software. There is no service to subscribe to and no
+account to hold — these terms describe the basis on which the software is
+provided to you.
+
+## Licence
+
+AIDE is licensed under the **MIT Licence**. The
+[LICENSE file](https://github.com/jmylchreest/aide/blob/main/LICENSE) in the
+repository is the authoritative and governing text. You may use, copy, modify,
+and redistribute AIDE under its terms. Where anything on this page conflicts
+with the MIT Licence, the licence prevails.
+
+## No warranty
+
+As stated in the licence, AIDE is provided **"as is", without warranty of any
+kind**, express or implied, including but not limited to the warranties of
+merchantability, fitness for a particular purpose, and non-infringement. The
+author is not liable for any claim, damages, or other liability arising from
+the use of the software.
+
+## Your responsibility when running an agent
+
+AIDE orchestrates AI agents that read, write, and delete files, run shell
+commands, and invoke other tools in your environment — including autonomously in
+modes such as swarm and autopilot. You are responsible for:
+
+- the code, commands, and changes produced in your environment;
+- reviewing agent output before committing, deploying, or releasing it;
+- keeping backups and version control so changes can be reverted;
+- the cost of any AI provider usage that AIDE initiates on your behalf; and
+- ensuring your use complies with the terms of your AI provider, your employer,
+  and any applicable law.
+
+Run AIDE only against repositories and systems you are authorised to modify.
+
+## Third-party services
+
+AIDE depends on services operated by others — your AI assistant and model
+provider, GitHub for releases and grammars, and any MCP servers you configure.
+Their terms and availability govern those components. AIDE makes no guarantee
+about them and is not responsible for their behaviour, cost, or downtime.
+
+## No support commitment
+
+Issues and pull requests are welcome, but the author provides AIDE voluntarily
+and offers no service-level commitment, guaranteed response time, or promise of
+continued maintenance.
+
+## Changes
+
+These terms are versioned in the
+[AIDE repository](https://github.com/jmylchreest/aide) and change through its
+commit history. Continued use of the software after a change constitutes
+acceptance of it.
+
+## Contact
+
+[github.com/jmylchreest/aide/issues](https://github.com/jmylchreest/aide/issues)

--- a/go.work.sum
+++ b/go.work.sum
@@ -386,6 +386,7 @@ golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -403,6 +404,7 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
Picks up the loose working-tree changes around registry listings.

- Adds `docs/src/pages/legal/privacy.md` and `terms.md`, links them from the docs footer, and points `websiteURL` / `privacyPolicyURL` / `termsOfServiceURL` in both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` at them.
- Adds the HOL trust and security badges to the README.

`go.work.sum` picked up two lines while building during the earlier watcher work.

### Dropped from this PR

An `.agents/plugins/marketplace.json` was originally included here. The HOL scanner picked it up as the codex scope's marketplace — `.codex-plugin/` has no `marketplace.json` of its own — which activated a previously inert 15-point Marketplace section and scored 5/15, taking the plugin from 94/100 (A) to 89/100 (B) on the very badges this PR adds. Two checks failed:

- `marketplace.json valid` — no `$schema`, and `"source": {"source": "local", "path": "./"}` where `.claude-plugin/marketplace.json` uses the plain string `"./"`.
- `Policy fields present` — the marketplace entry carries none of the three policy URLs.

Held back until that format is settled. When it returns it also needs adding to `VERSION_FILES` in the Makefile, since it embeds the release version the same way `.claude-plugin/marketplace.json` does and would otherwise be left behind by `make release`.

https://claude.ai/code/session_01DaZEV8Lf9j5xrRXuhV5mi1
