### PR TITLE
test(hooks): feed hook input over stdin instead of a shell pipeline

### DIFF
--- a/src/test/hooks.test.ts
+++ b/src/test/hooks.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { execSync, spawn } from "child_process";
+import { spawnSync } from "child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -184,26 +184,27 @@ describe("Persistence Hook", () => {
   });
 });
 
-// Helper function to run a hook
+// Helper function to run a hook.
+// Input goes over stdin rather than through a shell `echo`, which mangled any
+// payload containing a single quote.
 function runHook(hookName: string, input: string): any {
+  // Use compiled JS files from dist/
+  const jsName = hookName.replace(".ts", ".js");
+  const hookPath = join(PROJECT_ROOT, "dist", "hooks", jsName);
+  const result = spawnSync("node", [hookPath], {
+    input,
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+  if (result.error) throw result.error;
+
+  // A hook that exits non-zero still reports its decision on stdout.
   try {
-    // Use compiled JS files from dist/
-    const jsName = hookName.replace(".ts", ".js");
-    const hookPath = join(PROJECT_ROOT, "dist", "hooks", jsName);
-    const result = execSync(`echo '${input}' | node "${hookPath}"`, {
-      encoding: "utf-8",
-      timeout: 5000,
-    });
-    return JSON.parse(result.trim());
-  } catch (error: any) {
-    // If hook exits with non-zero, try to parse stdout
-    if (error.stdout) {
-      try {
-        return JSON.parse(error.stdout.trim());
-      } catch {
-        throw error;
-      }
-    }
-    throw error;
+    return JSON.parse(result.stdout.trim());
+  } catch (error) {
+    if (result.status === 0) throw error;
+    throw new Error(
+      `${jsName} exited ${result.status} with unparseable stdout: ${result.stdout}\n${result.stderr}`,
+    );
   }
 }

--- a/src/test/hooks.test.ts
+++ b/src/test/hooks.test.ts
@@ -205,6 +205,7 @@ function runHook(hookName: string, input: string): any {
     if (result.status === 0) throw error;
     throw new Error(
       `${jsName} exited ${result.status} with unparseable stdout: ${result.stdout}\n${result.stderr}`,
+      { cause: error },
     );
   }
 }


### PR DESCRIPTION
Makes the HOL Plugin Scanner check go green, by fixing the thing it was pointing at.

## What the scanner was flagging

One finding, reported once per scope (`claude:.` and `codex:.`) — hence `high:2`:

```
── [claude:.] Code Quality (5/10) ──
  ⚠️ No shell injection patterns                +0
Findings: critical:0, high:2, medium:0, low:0, info:26
Final Score: 94/100 (A - Excellent)
```

`SHELL_INJECTION_PATTERN` in `src/test/hooks.test.ts`, and it was a true positive:

```ts
const result = execSync(`echo '${input}' | node "${hookPath}"`, { ... });
```

`input` is a JSON payload interpolated into a shell string. A single quote anywhere in it breaks the command before the hook ever runs:

```
$ sh -c "echo '{...\"prompt\":\"it's quoted\"}' | node dist/hooks/skill-injector.js"
sh: -c: line 1: unexpected EOF while looking for matching `"'
```

So a test written to assert on a hook's decision would instead die in the shell — a latent failure waiting on the first payload with an apostrophe in it.

## The fix

`spawnSync` with an argv array, payload on stdin. No shell, no quoting, and the pattern is gone honestly rather than suppressed.

The helper simplifies as a side effect: `execSync` signalled a non-zero exit by *throwing* with stdout attached, so the JSON parse had to live in a `catch`. `spawnSync` reports status inline, and an unparseable stdout now names the hook, its exit code and its stderr instead of rethrowing a bare JSON syntax error.

## Verification

Ran `plugin-scanner==3.0.17` locally — the exact version the pinned action installs (`scanner-version.txt` in `ai-plugin-scanner-action@7e42024`; note it's the `plugin-scanner` PyPI package, not `codex-plugin-scanner`, which is a different and older 2.x line) — against a clean `git clone` of this repo:

| | before | after |
|---|---|---|
| Final score | 94/100 (A) | **100/100 (A)** |
| Findings | `high:2` | **`high:0`** |
| Code Quality | 5/10 | **10/10** |
| Exit code under `--fail-on high --min-score 80` | 1 | **0** |

`src/test/hooks.test.ts` passes 8/8. The suite's failing-test set is unchanged by this commit; the only two that differ between runs are both in `mcp-sync.test.ts`, which this doesn't touch and which is flaky on unmodified HEAD (3, 3, then 4 failures across three consecutive runs).

## On the workflow itself

No change needed. `plugin-scan.yml` already carries `continue-on-error: true`, so the job has never blocked a merge — the scanner's rule set lives outside this repo and a new heuristic shouldn't fail aide's builds. That stays exactly as it is: with the finding fixed the check simply goes green on its own, and if a future rule flags something real it shows red without gating anything. Suppressing the signal to force green would have thrown that away.

https://claude.ai/code/session_01DaZEV8Lf9j5xrRXuhV5mi1