### PR TITLE
fix(skill-injector): require a project marker before creating .aide/

### DIFF
--- a/src/hooks/skill-injector.ts
+++ b/src/hooks/skill-injector.ts
@@ -25,7 +25,8 @@ import {
   installHookSafetyNet,
   findAideBinary,
 } from "../lib/hook-utils.js";
-import { findProjectRoot } from "../lib/project-root.js";
+import { getAnchoredRoot } from "../lib/anchor.js";
+import { loadGlobalConfig } from "../core/session-init.js";
 import {
   discoverSkills as coreDiscoverSkills,
   matchSkills as coreMatchSkills,
@@ -67,10 +68,22 @@ let log: Logger | null = null;
 /**
  * Ensure .aide directories exist (minimal version for skill-injector)
  */
-function ensureDirectories(cwd: string): void {
-  // Resolve to the canonical project root so we don't plant a stray .aide/
-  // in a subdir the harness happened to launch from. See lib/project-root.ts.
-  const { root } = findProjectRoot(cwd);
+function ensureDirectories(cwd: string, sessionId: string): void {
+  // The anchor is the authoritative root: session-start resolves it via the
+  // Go binary once per session and caches it, so this is a cache read rather
+  // than a subprocess on the prompt path. Falls back to the TS walk.
+  const { root, hasMarker } = getAnchoredRoot({ sessionId, cwd });
+
+  // Same gate as session-start, aide-downloader and the Go binary. Creating
+  // .aide/ in an unmarked directory plants a project root wherever a hook
+  // happened to run, and every later walk-up beneath it resolves there —
+  // which for a shared directory like /tmp captures every project under it.
+  // loadGlobalConfig only runs in the unmarked case, so the hot path is free.
+  if (!hasMarker && (loadGlobalConfig().requireGit ?? true)) {
+    debugLog(`no .git/ or .aide/ marker above ${cwd}; skipping bootstrap`);
+    return;
+  }
+
   const dirs = [
     join(root, ".aide"),
     join(root, ".aide", "skills"),
@@ -166,7 +179,7 @@ async function main(): Promise<void> {
     // Ensure .aide directories exist
     debugLog("ensureDirectories starting...");
     log.start("ensureDirectories");
-    ensureDirectories(cwd);
+    ensureDirectories(cwd, sessionId);
     log.end("ensureDirectories");
     debugLog(`ensureDirectories complete (${Date.now() - hookStart}ms)`);
 

--- a/src/test/hooks.test.ts
+++ b/src/test/hooks.test.ts
@@ -75,6 +75,32 @@ This is a test skill.
   });
 
   it("should create .aide directories if missing", async () => {
+    const projectDir = join(tmpdir(), `aide-proj-${Date.now()}-${randomBytes(4).toString("hex")}`);
+    mkdirSync(projectDir);
+    // A VCS marker is what makes this a project root; without one the hook
+    // must not bootstrap. See the sibling test below.
+    mkdirSync(join(projectDir, ".git"));
+
+    const input = JSON.stringify({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "test-123",
+      cwd: projectDir,
+      prompt: "test",
+    });
+
+    runHook("skill-injector.ts", input);
+
+    // Directories should now exist
+    expect(existsSync(join(projectDir, ".aide"))).toBe(true);
+    expect(existsSync(join(projectDir, ".aide", "skills"))).toBe(true);
+
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  // Bootstrapping an unmarked directory plants a project root wherever a hook
+  // happened to run: every later walk-up beneath it then resolves there, so a
+  // single stray invocation with cwd=/tmp captures every project under /tmp.
+  it("should not create .aide directories without a project marker", async () => {
     const emptyDir = join(tmpdir(), `aide-empty-${Date.now()}-${randomBytes(4).toString("hex")}`);
     mkdirSync(emptyDir);
 
@@ -87,9 +113,7 @@ This is a test skill.
 
     runHook("skill-injector.ts", input);
 
-    // Directories should now exist
-    expect(existsSync(join(emptyDir, ".aide"))).toBe(true);
-    expect(existsSync(join(emptyDir, ".aide", "skills"))).toBe(true);
+    expect(existsSync(join(emptyDir, ".aide"))).toBe(false);
 
     rmSync(emptyDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
`ensureDirectories` resolved a root and `mkdirSync`'d unconditionally. Any hook invocation whose cwd had no `.git/` or `.aide/` above it planted a project root right there — and every later walk-up beneath that directory then resolved to it.

Handing the hook `cwd=/tmp` is all it takes:

```
$ echo '{"hook_event_name":"UserPromptSubmit","cwd":"/tmp",...}' | node dist/hooks/skill-injector.js
$ ls -d /tmp/.aide
/tmp/.aide
```

From that point every temp-dir fixture on the machine resolves to `/tmp` instead of itself. I did this to myself during the previous PR and spent a while chasing 25 phantom test failures across five files that vanished the moment `/tmp/.aide` was removed.

## Why this one was wrong

Every other caller already gates on `hasMarker`:

| | gate |
|---|---|
| `aide/cmd/aide/main.go:91` | `if !hasMarker && !forceInit` — *"Skip creating .aide/ directories to avoid polluting arbitrary dirs"* |
| `src/hooks/session-start.ts:382` | gates, honouring `requireGit` |
| `src/lib/aide-downloader.ts:575` | gates, honouring `requireGit` |
| `src/opencode/resolve-root.ts:49` | gates |
| `src/core/session-init.ts:42` | documents the contract: *"caller's hasMarker gate elsewhere refuses bootstrap unless AIDE_FORCE_INIT is set"* |

`skill-injector` was the last outlier — its comment was a near-copy of `session-init`'s, minus the gate.

## Using the anchor

The root now comes from `getAnchoredRoot` rather than `findProjectRoot`, so the gate reads `hasMarker` from the same authority that decided the root, instead of a second independent walk.

This is a cache read on the prompt hot path, not a subprocess: `session-start` already resolves the anchor via `aide anchor --json` once per session and persists it with `writeSessionAnchor`, and `getAnchoredRoot`'s ladder is session cache → binary (only if one is passed, which it isn't here) → TS walk. So a normal session hits the cache the Go resolver populated, and a session without one degrades to exactly today's behaviour.

`getAnchoredRoot` was written for precisely this shape — *"the common consumer shape for hooks that only need a root"* — and had no callers until now.

`loadGlobalConfig()` is only consulted when the marker is missing (short-circuit), so the common path costs nothing extra.

## Tests

The existing `should create .aide directories if missing` asserted the ungated behaviour, so it now marks its fixture with `.git` before asserting the bootstrap, and a sibling asserts an unmarked directory is left alone.

Verified the new test actually catches the bug — reverting just the hook and rebuilding:

```
=== with the OLD ungated hook ===
 FAIL  should not create .aide directories without a project marker
      Tests  1 failed | 8 passed (9)
=== with the fix ===
      Tests  9 passed (9)
```

Full suite: 347 passed (347), and `/tmp` stays clean across runs.

https://claude.ai/code/session_01DaZEV8Lf9j5xrRXuhV5mi1