### PR TITLE
fix(hud): require a project marker before writing .aide/state

### DIFF
--- a/src/hooks/hud-updater.ts
+++ b/src/hooks/hud-updater.ts
@@ -98,7 +98,7 @@ async function main(): Promise<void> {
 
     // Load config and get state
     log.start("loadHudConfig");
-    const config = loadHudConfig(cwd);
+    const config = loadHudConfig(cwd, sessionId);
     log.end("loadHudConfig");
 
     log.start("getSessionState");
@@ -123,7 +123,7 @@ async function main(): Promise<void> {
     log.debug(`HUD output: ${hudOutput}`);
 
     log.start("writeHudOutput");
-    writeHudOutput(cwd, hudOutput);
+    writeHudOutput(cwd, hudOutput, sessionId);
     log.end("writeHudOutput");
 
     log.end("total");

--- a/src/lib/hud.ts
+++ b/src/lib/hud.ts
@@ -16,7 +16,8 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { execFileSync } from "child_process";
 import { runAide, findAideBinary } from "./hook-utils.js";
-import { findProjectRoot } from "./project-root.js";
+import { getAnchoredRoot } from "./anchor.js";
+import { loadGlobalConfig } from "../core/session-init.js";
 
 // Cache the aide version for the session (won't change)
 let aideVersionCache: string | null = null;
@@ -263,8 +264,8 @@ export function getAgentStates(cwd: string): AgentState[] {
 /**
  * Load HUD configuration
  */
-export function loadHudConfig(cwd: string): HudConfig {
-  const { root } = findProjectRoot(cwd);
+export function loadHudConfig(cwd: string, sessionId?: string): HudConfig {
+  const { root } = getAnchoredRoot({ sessionId, cwd });
   const configPath = join(root, ".aide", "config", "hud.json");
 
   if (existsSync(configPath)) {
@@ -570,8 +571,17 @@ export function formatHud(
 /**
  * Write HUD output to state file
  */
-export function writeHudOutput(cwd: string, output: string): void {
-  const { root } = findProjectRoot(cwd);
+export function writeHudOutput(
+  cwd: string,
+  output: string,
+  sessionId?: string,
+): void {
+  const { root, hasMarker } = getAnchoredRoot({ sessionId, cwd });
+  // Same gate as skill-injector, session-start and the Go binary: creating
+  // .aide/ in an unmarked directory plants a project root wherever a hook
+  // happened to run, and every later walk-up beneath it resolves there.
+  if (!hasMarker && (loadGlobalConfig().requireGit ?? true)) return;
+
   const stateDir = join(root, ".aide", "state");
   if (!existsSync(stateDir)) {
     try {
@@ -594,7 +604,7 @@ export function writeHudOutput(cwd: string, output: string): void {
  * Can be called from any hook that needs to trigger a HUD update.
  */
 export function refreshHud(cwd: string, sessionId?: string): void {
-  const config = loadHudConfig(cwd);
+  const config = loadHudConfig(cwd, sessionId);
   const state = getSessionState(cwd, sessionId);
   const allAgents = getAgentStates(cwd);
 
@@ -604,5 +614,5 @@ export function refreshHud(cwd: string, sessionId?: string): void {
     : [];
 
   const hudOutput = formatHud(config, state, agents, cwd);
-  writeHudOutput(cwd, hudOutput);
+  writeHudOutput(cwd, hudOutput, sessionId);
 }

--- a/src/test/hud-root.test.ts
+++ b/src/test/hud-root.test.ts
@@ -1,0 +1,41 @@
+/**
+ * writeHudOutput creates .aide/state under the resolved project root, so it
+ * carries the same risk skill-injector did: bootstrapping an unmarked
+ * directory plants a project root wherever a hook happened to run, and every
+ * later walk-up beneath it resolves there.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { randomBytes } from "crypto";
+
+import { writeHudOutput } from "../lib/hud.js";
+
+describe("writeHudOutput project-marker gate", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `aide-hud-${Date.now()}-${randomBytes(4).toString("hex")}`);
+    mkdirSync(dir);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes the HUD under a marked project root", () => {
+    mkdirSync(join(dir, ".git"));
+
+    writeHudOutput(dir, "hud line");
+
+    expect(existsSync(join(dir, ".aide", "state", "hud.txt"))).toBe(true);
+  });
+
+  it("leaves an unmarked directory alone", () => {
+    writeHudOutput(dir, "hud line");
+
+    expect(existsSync(join(dir, ".aide"))).toBe(false);
+  });
+});


### PR DESCRIPTION
The same bug #66 fixed, in the one other place it survived.

`writeHudOutput` resolved a root via bare `findProjectRoot` and then created `<root>/.aide/state` under it with no marker check. It's on a hook path — `hud-updater` runs on PostToolUse — so an unmarked cwd got a project root planted in it, and every later walk-up beneath that directory then resolved there. That's what made `/tmp` an aide project root during #65 and produced 25 phantom test failures across five files.

## Change

Both hud entry points now resolve through `getAnchoredRoot` instead of `findProjectRoot`, so the HUD agrees with the Go resolver about where the project is rather than re-deriving it. `writeHudOutput` gates on `hasMarker` before creating anything, matching `skill-injector`, `session-start`, `aide-downloader` and the Go binary; `loadHudConfig` only reads, so it takes the anchored root without the gate.

Threading was already half-done: `refreshHud(cwd, sessionId?)` carried a session id and just didn't pass it down, and `hud-updater` has one in scope at line 65. Without a session the anchor ladder falls back to the TS walk, i.e. exactly today's behaviour, so nothing regresses for callers that don't have one.

## Tests

`src/test/hud-root.test.ts` covers both sides of the gate — there were no hud tests before. Verified it catches the real thing by reverting only `hud.ts` and rebuilding:

```
=== against the OLD ungated hud ===
 FAIL  writeHudOutput project-marker gate > leaves an unmarked directory alone
      Tests  1 failed | 1 passed (2)
=== with the fix ===
      Tests  2 passed (2)
```

Full suite: 349 passed (349), `/tmp` clean across runs.

## Not in scope

The remaining `findProjectRoot` callers that would benefit from the anchor — `codeWatchEnabled`/`reflectEnabled` in `hook-utils`, `loadConfig`/`cleanupStaleStateFiles`/`resetHudState` in `session-init`, and `mcp-sync`'s project path — all need a `sessionId` threaded through first, which is an API change across three modules. Raised separately.

Two logging sites (`logger.ts:344`, `session-end.ts:172`) also create `.aide/_logs` ungated; both are deliberate and low-impact, noted in that issue rather than changed here.

https://claude.ai/code/session_01DaZEV8Lf9j5xrRXuhV5mi1